### PR TITLE
Remove lightning option and add wind enhancements

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -20,13 +20,31 @@ html,body,#map{height:100%;margin:0}
   box-shadow:0 2px 10px rgba(0,0,0,.12);
   font:14px/1.35 system-ui,Segoe UI,Roboto,Ubuntu,Arial,sans-serif;
   max-width:min(92vw,560px);
-  display:grid; gap:8px;
+  display:flex; flex-direction:column; gap:8px;
 }
+.panel.collapsed{gap:0;}
+.panel-header{display:flex;align-items:center;justify-content:space-between;gap:12px;}
+.panel-header strong{font-size:14px;letter-spacing:0.01em;}
+.panel-body{display:grid;gap:8px;}
+.panel.collapsed .panel-body{display:none;}
+.panel.collapsed .panel-toggle{transform:rotate(-90deg);}
+.panel-toggle{
+  border:none; border-radius:6px;
+  background:rgba(0,0,0,0.08);
+  color:inherit;
+  padding:4px 8px;
+  font-size:14px;
+  cursor:pointer;
+  transition:transform .2s ease;
+}
+.panel-toggle:focus-visible{outline:2px solid #1976d2; outline-offset:2px;}
+body.dark .panel-toggle{background:rgba(255,255,255,0.12);}
 .row{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
 .row label{white-space:nowrap;font-weight:600}
 .grow{flex:1 1 auto}
 .hint{font-size:12px;color:var(--fg-hint)}
 .badge{display:inline-block;padding:2px 6px;border-radius:6px;font-size:12px;background:#eef;color:#223}
+body.dark .badge{background:rgba(33,150,243,0.35);color:#e3f2fd;}
 
 /* Legende oben rechts */
 .legend{
@@ -45,22 +63,11 @@ html,body,#map{height:100%;margin:0}
 }
 .legend .ticks{display:flex;justify-content:space-between;color:var(--fg-hint)}
 
-/* Blitz-Zähler rechts oben unter Legende */
-.lightning-counter{
-  position:absolute;
-  right:max(10px,env(safe-area-inset-right));
-  top:calc(10px + 60px);
-  z-index:1001;
-  background:var(--bg-panel); color:var(--fg-text);
-  padding:4px 8px; border-radius:6px; font:12px system-ui;
-  box-shadow:0 1px 6px rgba(0,0,0,.08); pointer-events:none;
-}
-
 /* Warnliste rechts oben (unter Counter/Legende) */
 .warnlist{
   position:absolute;
   right:max(10px,env(safe-area-inset-right));
-  top:calc(10px + 60px + 28px + 8px);
+  top:calc(10px + 60px + 8px);
   z-index:1001;
   background:var(--bg-panel); color:var(--fg-text);
   padding:8px 10px; border-radius:8px;
@@ -90,3 +97,40 @@ html,body,#map{height:100%;margin:0}
 
 /* Radar-Frames weich überblenden */
 .rv-tiles{transition:opacity .28s linear; will-change:opacity}
+
+/* Standort-Markierung */
+.loc-icon{display:flex;align-items:center;justify-content:center;}
+.loc-marker{
+  width:32px; height:32px;
+  border-radius:50%;
+  border:3px solid #0d47a1;
+  background:radial-gradient(circle at 50% 50%, #fff 0%, #64b5f6 45%, #1976d2 100%);
+  position:relative;
+  box-shadow:0 0 10px rgba(33,150,243,0.45);
+}
+.loc-marker::after{
+  content:"";
+  position:absolute;
+  top:50%; left:50%; transform:translate(-50%,-50%);
+  width:10px; height:10px;
+  background:#fff; border-radius:50%;
+  box-shadow:0 0 4px rgba(0,0,0,0.2);
+}
+.loc-pointer{
+  position:absolute;
+  top:-12px; left:50%;
+  width:6px; height:18px;
+  background:#0d47a1;
+  border-radius:3px 3px 0 0;
+  transform-origin:50% 16px;
+  transform:translateX(-50%) rotate(var(--rot,0deg));
+  box-shadow:0 2px 4px rgba(0,0,0,0.2);
+}
+
+.leaflet-tooltip.wind-tooltip{
+  background:rgba(25,118,210,0.9);
+  border:none;
+  color:#fff;
+  font-weight:600;
+  box-shadow:0 2px 6px rgba(0,0,0,0.25);
+}

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="utf-8" />
-  <title>Wetterradar – Radar, Wolken, Blitze, Warnungen</title>
+  <title>Wetterradar – Radar, Wolken, Wind, Warnungen</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/css/app.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
@@ -12,55 +12,61 @@
   <div id="map" role="region" aria-label="Wetterradar"></div>
 
   <!-- Panel unten links -->
-  <div class="panel">
-    <div class="row">
-      <button id="btnPrev">⟵</button>
-      <button id="btnPlay">▶︎</button>
-      <button id="btnNext">⟶</button>
-      <div class="grow" id="lblTime">Lade…</div>
-      <button id="btnLocate">📍</button>
-      <span id="lblCity" class="badge" style="display:none"></span>
+  <div class="panel" id="controlPanel">
+    <div class="panel-header">
+      <strong>Steuerung</strong>
+      <button id="btnPanelToggle" class="panel-toggle" aria-expanded="true" aria-label="Bedienpanel einklappen">▾</button>
     </div>
-    <div class="row">
-      <label for="selColor">Farbschema</label>
-      <select id="selColor">
-        <option value="4" selected>4</option>
-        <option value="3">3</option>
-        <option value="2">2</option>
-      </select>
-      <label for="chkSmooth">Smooth</label>
-      <input type="checkbox" id="chkSmooth" checked>
-      <label for="rngSpeed">⏩</label>
-      <input id="rngSpeed" type="range" min="200" max="1200" step="100" value="700" class="grow">
-    </div>
-    <div class="row">
-      <label for="rngOpacity">Deckkraft Radar</label>
-      <input id="rngOpacity" type="range" min="0.2" max="1" step="0.05" value="0.85" class="grow">
-      <span id="lblOpacity">85%</span>
-    </div>
-    <div class="row">
-      <label for="chkClouds">Wolken</label>
-      <input type="checkbox" id="chkClouds">
-      <input id="rngClouds" type="range" min="0.2" max="1" step="0.05" value="0.7" class="grow">
-      <span id="lblClouds">70%</span>
-    </div>
-    <div class="row">
-      <label for="chkLightning">Blitze (live)</label>
-      <input type="checkbox" id="chkLightning" checked>
-      <span class="hint">letzte 10 Min im Sichtbereich</span>
-    </div>
-    <div class="row">
-      <label for="chkWarn">Wetterwarnungen (DWD)</label>
-      <input type="checkbox" id="chkWarn">
-      <label for="chkWarnList">Warnliste</label>
-      <input type="checkbox" id="chkWarnList">
-      <label for="chkWarnInView">nur im Kartenausschnitt</label>
-      <input type="checkbox" id="chkWarnInView" checked>
-    </div>
+    <div class="panel-body" id="panelBody">
+      <div class="row">
+        <button id="btnPrev">⟵</button>
+        <button id="btnPlay">▶︎</button>
+        <button id="btnNext">⟶</button>
+        <div class="grow" id="lblTime">Lade…</div>
+        <button id="btnLocate">📍</button>
+        <span id="lblLocationWind" class="badge" style="display:none"></span>
+      </div>
+      <div class="row">
+        <label for="selColor">Farbschema</label>
+        <select id="selColor">
+          <option value="4" selected>4</option>
+          <option value="3">3</option>
+          <option value="2">2</option>
+        </select>
+        <label for="chkSmooth">Smooth</label>
+        <input type="checkbox" id="chkSmooth" checked>
+        <label for="rngSpeed">⏩</label>
+        <input id="rngSpeed" type="range" min="200" max="1200" step="100" value="700" class="grow">
+      </div>
+      <div class="row">
+        <label for="rngOpacity">Deckkraft Radar</label>
+        <input id="rngOpacity" type="range" min="0.2" max="1" step="0.05" value="0.85" class="grow">
+        <span id="lblOpacity">85%</span>
+      </div>
+      <div class="row">
+        <label for="chkClouds">Wolken</label>
+        <input type="checkbox" id="chkClouds">
+        <input id="rngClouds" type="range" min="0.2" max="1" step="0.05" value="0.7" class="grow">
+        <span id="lblClouds">70%</span>
+      </div>
+      <div class="row">
+        <label for="chkWindFlow">Windströmung</label>
+        <input type="checkbox" id="chkWindFlow">
+        <span class="hint">animiertes Feld (experimentell)</span>
+      </div>
+      <div class="row">
+        <label for="chkWarn">Wetterwarnungen (DWD)</label>
+        <input type="checkbox" id="chkWarn">
+        <label for="chkWarnList">Warnliste</label>
+        <input type="checkbox" id="chkWarnList">
+        <label for="chkWarnInView">nur im Kartenausschnitt</label>
+        <input type="checkbox" id="chkWarnInView" checked>
+      </div>
 
-    <div class="row">
-      <label for="chkDark">Dark-Mode</label>
-      <input type="checkbox" id="chkDark">
+      <div class="row">
+        <label for="chkDark">Dark-Mode</label>
+        <input type="checkbox" id="chkDark">
+      </div>
     </div>
   </div>
 
@@ -70,8 +76,6 @@
     <div class="scale"></div>
     <div class="ticks"><span>Leicht</span><span>Mittel</span><span>Stark</span></div>
   </div>
-
-  <div id="lightningCounter" class="lightning-counter">⚡ Blitze im Sichtbereich: 0 (10 min)</div>
 
   <div id="warnList" class="warnlist" style="display:none;">
     <div class="title">Aktuelle Wetterwarnungen (DWD)</div>
@@ -85,6 +89,7 @@
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
           integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin></script>
+  <script src="https://unpkg.com/leaflet-velocity/dist/leaflet-velocity.min.js"></script>
   <script type="module" src="/js/app.js"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,8 +1,8 @@
 import { OSM_URL, PLAY_FADE_MS } from './config.js';
 import * as Radar from './radar.js';
 import * as Sat from './satellite.js';
-import { bind as bindLightning } from './lightning.js';
 import { bind as bindWarnings } from './warnings.js';
+import { setWindFlow } from './windflow.js';
 
 const map = L.map('map', { zoomSnap:0.5, worldCopyJump:true, maxZoom:10 }).setView([51.2,10.5], 6);
 L.tileLayer(OSM_URL, { maxZoom:19, attribution:'© OpenStreetMap-Mitwirkende' }).addTo(map);
@@ -15,18 +15,55 @@ map.createPane('cloudPane');  map.getPane('cloudPane').style.zIndex = 500;
 const $ = id => document.getElementById(id);
 const ui = {
   btnPrev: $('btnPrev'), btnNext:$('btnNext'), btnPlay:$('btnPlay'),
-  lblTime:$('lblTime'), btnLocate:$('btnLocate'), lblCity:$('lblCity'),
+  lblTime:$('lblTime'), btnLocate:$('btnLocate'), lblLocationWind:$('lblLocationWind'),
   selColor:$('selColor'), chkSmooth:$('chkSmooth'), rngSpeed:$('rngSpeed'),
   rngOpacity:$('rngOpacity'), lblOpacity:$('lblOpacity'),
   chkClouds:$('chkClouds'), rngClouds:$('rngClouds'), lblClouds:$('lblClouds'),
-  chkLightning:$('chkLightning'),
   chkWarn:$('chkWarn'), chkWarnList:$('chkWarnList'),
   chkDark:$('chkDark'),
+  chkWindFlow:$('chkWindFlow'),
+  controlPanel:$('controlPanel'),
+  btnPanelToggle:$('btnPanelToggle'),
 };
 
 // Modules
-bindLightning(L, map, ui);
 bindWarnings(L, map, ui);
+
+if(ui.btnPanelToggle && ui.controlPanel){
+  ui.btnPanelToggle.onclick = ()=>{
+    const collapsed = ui.controlPanel.classList.toggle('collapsed');
+    ui.btnPanelToggle.setAttribute('aria-expanded', String(!collapsed));
+    ui.btnPanelToggle.textContent = collapsed ? '▸' : '▾';
+    ui.btnPanelToggle.setAttribute('aria-label', collapsed ? 'Bedienpanel ausklappen' : 'Bedienpanel einklappen');
+  };
+}
+
+let windFlowLoading = false;
+const windFlowHint = ui.chkWindFlow?.closest('.row')?.querySelector('.hint');
+const windFlowHintText = windFlowHint?.textContent ?? '';
+if(ui.chkWindFlow){
+  ui.chkWindFlow.onchange = async ()=>{
+    if(ui.chkWindFlow.checked){
+      if(windFlowLoading) return;
+      windFlowLoading = true;
+      ui.chkWindFlow.disabled = true;
+      if(windFlowHint) windFlowHint.textContent = 'lädt…';
+      try{
+        await setWindFlow(L, map, true);
+      }catch(err){
+        console.warn('Windströmung konnte nicht geladen werden:', err);
+        alert('Windströmung konnte nicht geladen werden.');
+        ui.chkWindFlow.checked = false;
+      }finally{
+        windFlowLoading = false;
+        ui.chkWindFlow.disabled = false;
+        if(windFlowHint) windFlowHint.textContent = windFlowHintText;
+      }
+    }else{
+      setWindFlow(L, map, false);
+    }
+  };
+}
 
 function syncClouds(timeUnix){ Sat.syncTo(timeUnix); }
 
@@ -60,12 +97,132 @@ async function boot(){
 
   ui.chkDark.onchange = ()=> document.body.classList.toggle('dark', ui.chkDark.checked);
 
-  ui.btnLocate.onclick = ()=> navigator.geolocation?.getCurrentPosition(pos=>{
-    const {latitude, longitude, accuracy}=pos.coords;
-    const zoom= accuracy<=50?14:accuracy<=150?12:accuracy<=1000?10:9;
-    map.setView([latitude,longitude], Math.min(zoom, map.getMaxZoom()));
-    L.circle([latitude,longitude], {radius:accuracy, weight:1}).addTo(map);
-  });
+  const locationTooltipOptions = { permanent:true, direction:'top', offset:[0,-22], className:'wind-tooltip' };
+  let locateMarker=null, locateCircle=null;
+
+  function setWindBadge(text, visible=true){
+    if(!ui.lblLocationWind) return;
+    if(!visible){
+      if(text) ui.lblLocationWind.textContent = text;
+      ui.lblLocationWind.style.display = 'none';
+      return;
+    }
+    if(!text){
+      ui.lblLocationWind.textContent = '';
+      ui.lblLocationWind.style.display = 'none';
+      return;
+    }
+    ui.lblLocationWind.textContent = text;
+    ui.lblLocationWind.style.display = 'inline-block';
+  }
+  const showWindLoading = ()=> setWindBadge('Wind wird geladen…');
+  const showWindError = (msg='Winddaten nicht verfügbar')=> setWindBadge(msg);
+  const showWindInfo = info => {
+    if(!info) return setWindBadge('Winddaten nicht verfügbar');
+    const dirText = Number.isFinite(info.direction) ? `${Math.round(info.direction)}°` : '–';
+    const speedText = Number.isFinite(info.speedKmh) ? info.speedKmh.toFixed(1) : '–';
+    setWindBadge(`Wind: ${speedText} km/h (${dirText})`);
+  };
+
+  function updateAccuracyCircle(lat, lon, accuracy){
+    const safeRadius = Math.max(Number(accuracy) || 0, 30);
+    const style = { color:'#1976d2', weight:2, fillColor:'#64b5f6', fillOpacity:0.18 };
+    if(locateCircle){
+      locateCircle.setLatLng([lat, lon]);
+      locateCircle.setRadius(safeRadius);
+      locateCircle.setStyle(style);
+    }else{
+      locateCircle = L.circle([lat, lon], { ...style, radius: safeRadius }).addTo(map);
+    }
+  }
+
+  function updateLocationMarker(lat, lon, direction){
+    const rot = Number.isFinite(direction) ? direction : 0;
+    const pointerStyle = Number.isFinite(direction) ? `--rot:${rot}deg;` : '--rot:0deg;opacity:0;';
+    const icon = L.divIcon({
+      className:'loc-icon',
+      html:`<div class="loc-marker"><div class="loc-pointer" style="${pointerStyle}"></div></div>`,
+      iconSize:[36,36], iconAnchor:[18,18], tooltipAnchor:[0,-20],
+    });
+    if(locateMarker){
+      locateMarker.setLatLng([lat, lon]);
+      locateMarker.setIcon(icon);
+    }else{
+      locateMarker = L.marker([lat, lon], {icon}).addTo(map);
+    }
+    return locateMarker;
+  }
+
+  async function fetchWindInfo(lat, lon){
+    const params = new URLSearchParams({
+      latitude: lat.toFixed(3),
+      longitude: lon.toFixed(3),
+      current_weather: 'true',
+      windspeed_unit: 'ms',
+      timezone: 'auto',
+    });
+    const res = await fetch(`https://api.open-meteo.com/v1/forecast?${params.toString()}`, { cache:'no-store' });
+    if(!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const cw = data?.current_weather;
+    if(!cw) throw new Error('Keine aktuellen Winddaten');
+    const speedMsRaw = Number(cw.windspeed);
+    const directionRaw = Number(cw.winddirection ?? cw.wind_direction);
+    const speedMs = Number.isFinite(speedMsRaw) ? speedMsRaw : null;
+    return {
+      speedMs,
+      speedKmh: speedMs == null ? null : speedMs * 3.6,
+      direction: Number.isFinite(directionRaw) ? directionRaw : null,
+    };
+  }
+
+  function updateWindTooltip(marker, info){
+    if(!marker) return;
+    if(!info){
+      if(marker.getTooltip()) marker.setTooltipContent('Winddaten nicht verfügbar');
+      else marker.bindTooltip('Winddaten nicht verfügbar', locationTooltipOptions);
+      return;
+    }
+    const dirText = Number.isFinite(info.direction) ? `${Math.round(info.direction)}°` : '–';
+    const speedKmhText = Number.isFinite(info.speedKmh) ? info.speedKmh.toFixed(1) : '–';
+    const speedMsText = Number.isFinite(info.speedMs) ? info.speedMs.toFixed(1) : '–';
+    const content = `Wind: ${speedKmhText} km/h (${speedMsText} m/s)<br>Richtung: ${dirText}`;
+    if(marker.getTooltip()) marker.setTooltipContent(content);
+    else marker.bindTooltip(content, locationTooltipOptions);
+  }
+
+  ui.btnLocate.onclick = ()=>{
+    if(!navigator.geolocation){
+      showWindError('Standortbestimmung nicht unterstützt');
+      alert('Geolokalisierung wird von diesem Browser nicht unterstützt.');
+      return;
+    }
+    ui.btnLocate.disabled = true;
+    showWindLoading();
+    navigator.geolocation.getCurrentPosition(async pos=>{
+      const { latitude, longitude, accuracy } = pos.coords;
+      const zoom= accuracy<=50?14:accuracy<=150?12:accuracy<=1000?10:9;
+      map.setView([latitude,longitude], Math.min(zoom, map.getMaxZoom()));
+      updateAccuracyCircle(latitude, longitude, accuracy);
+      const marker = updateLocationMarker(latitude, longitude, null);
+      try{
+        const wind = await fetchWindInfo(latitude, longitude);
+        updateLocationMarker(latitude, longitude, wind.direction ?? null);
+        updateWindTooltip(marker, wind);
+        showWindInfo(wind);
+      }catch(err){
+        console.warn('Winddaten konnten nicht geladen werden:', err);
+        updateWindTooltip(marker, null);
+        showWindError();
+      }finally{
+        ui.btnLocate.disabled = false;
+      }
+    }, err=>{
+      console.warn('Geolokalisierung fehlgeschlagen:', err);
+      ui.btnLocate.disabled = false;
+      showWindError('Standort nicht verfügbar');
+    }, { enableHighAccuracy:true, maximumAge:120000, timeout:15000 });
+  };
 
   // regelmäßige Aktualisierung
   setInterval(async ()=>{ await Radar.loadRadar(); Radar.paint(L,map,ui,syncClouds); }, 5*60*1000);

--- a/js/config.js
+++ b/js/config.js
@@ -10,5 +10,3 @@ export const DWD_WMS_LAYER = 'dwd:Warnungen_Landkreise';
 export const DWD_WARN_JSON = '/dwd/warnings.json';
 export const DWD_WFS = 'https://maps.dwd.de/geoserver/dwd/ows?service=WFS&version=2.0.0&request=GetFeature&typeNames=dwd:Warnungen_Landkreise&outputFormat=application/json';
 
-export const SSE_LIGHTNING = '/blitze';       // dein Proxy via Nginx
-export const STRIKE_RETAIN_MS = 10 * 60 * 1000; // 10 Minuten

--- a/js/windflow.js
+++ b/js/windflow.js
@@ -1,18 +1,64 @@
-export async function enableWindFlow(L, map){
-  // Wenn du eigene /wind/current.json erzeugst, nimm die:
-  let resp = await fetch('/wind/current.json', {cache:'no-store'});
-  if(!resp.ok) resp = await fetch('/wind/wind.json', {cache:'no-store'});
-  const data = await resp.json();
+let layer = null;
+let loading = null;
 
-  map.createPane('windPane'); map.getPane('windPane').style.zIndex=480;
-  const isMobile=/iphone|ipad|android|mobile/i.test(navigator.userAgent);
-  const layer = L.velocityLayer({
-    data, pane:'windPane',
-    velocityScale:0.008, maxVelocity:25,
-    lineWidth: isMobile?0.8:1.0,
-    particleMultiplier: isMobile?1/350:1/200,
-    displayValues:true,
-    displayOptions:{ position:'bottomleft', emptyString:'Keine Winddaten', velocityType:'Wind', speedUnit:'m/s', directionString:'Richtung' }
-  });
-  layer.addTo(map);
+async function fetchWindField(){
+  let resp = await fetch('/wind/current.json', { cache:'no-store' });
+  if(!resp.ok){
+    resp = await fetch('/wind/wind.json', { cache:'no-store' });
+  }
+  if(!resp.ok){
+    throw new Error('Winddaten nicht verfügbar');
+  }
+  return await resp.json();
+}
+
+export async function setWindFlow(L, map, enabled){
+  if(!enabled){
+    if(layer){ map.removeLayer(layer); }
+    return null;
+  }
+  if(layer){
+    layer.addTo(map);
+    return layer;
+  }
+  if(loading) return loading;
+
+  loading = (async()=>{
+    try{
+      if(typeof L.velocityLayer !== 'function'){
+        throw new Error('leaflet-velocity nicht geladen');
+      }
+      const data = await fetchWindField();
+      if(!map.getPane('windPane')){
+        map.createPane('windPane');
+        map.getPane('windPane').style.zIndex = 480;
+      }
+      const isMobile = /iphone|ipad|android|mobile/i.test(navigator.userAgent);
+      layer = L.velocityLayer({
+        data,
+        pane: 'windPane',
+        velocityScale:0.008,
+        maxVelocity:25,
+        lineWidth: isMobile ? 0.8 : 1.0,
+        particleMultiplier: isMobile ? 1/350 : 1/200,
+        displayValues:true,
+        displayOptions:{
+          position:'bottomleft',
+          emptyString:'Keine Winddaten',
+          velocityType:'Wind',
+          speedUnit:'m/s',
+          directionString:'Richtung'
+        }
+      });
+      layer.addTo(map);
+      return layer;
+    }catch(err){
+      layer = null;
+      throw err;
+    }finally{
+      loading = null;
+    }
+  })();
+
+  return loading;
 }


### PR DESCRIPTION
## Summary
- remove the lightning/"Blitzer" UI, add a collapsible control panel, and surface a wind flow toggle
- enlarge the geolocation marker, show live wind speed from Open-Meteo, and style the accompanying badge/tooltip
- wire up the optional wind flow layer with graceful loading/fallbacks and adjust layout styles

## Testing
- not run (UI-focused changes)


------
https://chatgpt.com/codex/tasks/task_e_68ca49ceac0483308672a61079033d23