### PR TITLE
Add wind data location to nginx example

### DIFF
--- a/etc/nginx/sites-available/wetter.domain.tld
+++ b/etc/nginx/sites-available/wetter.domain.tld
@@ -82,6 +82,16 @@ server {
         add_header Cache-Control "public, max-age=2592000, immutable";
     }
 
+    # --- Windströmungsdaten (leaflet-velocity) ---
+    # Erwartet JSON-Dateien unter /var/www/wetterradar/data/wind/
+    location ^~ /wind/ {
+        root /var/www/wetterradar/data;
+        default_type application/json;
+        add_header Access-Control-Allow-Origin *;
+        add_header Cache-Control "public, max-age=120, stale-while-revalidate=600";
+        try_files $uri =404;
+    }
+
     # ACME-Challenge (für Certbot Webroot)
     location ^~ /.well-known/acme-challenge/ {
         root /var/www/wetter;


### PR DESCRIPTION
## Summary
- document a dedicated /wind location in the nginx sample vhost
- serve JSON wind field files from /var/www/wetterradar/data with caching and CORS headers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca50cd52d483308273fbc7876e87fd