### PR TITLE
Ensure satellite layer refreshes with RainViewer updates

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -225,7 +225,13 @@ async function boot(){
   };
 
   // regelmäßige Aktualisierung
-  setInterval(async ()=>{ await Radar.loadRadar(); Radar.paint(L,map,ui,syncClouds); }, 5*60*1000);
+  setInterval(async ()=>{
+    await Promise.all([Radar.loadRadar(), Sat.loadSatellite()]);
+    const frames = Radar.getFrames();
+    const current = frames[Radar.getIndex()];
+    if(current) syncClouds(current.time);
+    Radar.paint(L,map,ui,syncClouds);
+  }, 5*60*1000);
 }
 
 boot();


### PR DESCRIPTION
## Summary
- refresh both radar and infrared satellite data during the periodic RainViewer update
- resync any visible cloud layer to the freshly loaded satellite frames before repainting the radar map

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d014ea89188330aa0786a6804e40b6