### PR TITLE
Filter warnings list to current map view and add wind flow overlay toggle

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2,7 +2,7 @@ import { OSM_URL, PLAY_FADE_MS } from './config.js';
 import * as Radar from './radar.js';
 import * as Sat from './satellite.js';
 import { bind as bindWarnings } from './warnings.js';
-import { setWindFlow } from './windflow.js';
+import { bindWindFlow } from './windflow.js';
 
 const map = L.map('map', { zoomSnap:0.5, worldCopyJump:true, maxZoom:10 }).setView([51.2,10.5], 6);
 L.tileLayer(OSM_URL, { maxZoom:19, attribution:'© OpenStreetMap-Mitwirkende' }).addTo(map);
@@ -28,6 +28,7 @@ const ui = {
 
 // Modules
 bindWarnings(L, map, ui);
+bindWindFlow(L, map, ui);
 
 if(ui.btnPanelToggle && ui.controlPanel){
   ui.btnPanelToggle.onclick = ()=>{
@@ -35,33 +36,6 @@ if(ui.btnPanelToggle && ui.controlPanel){
     ui.btnPanelToggle.setAttribute('aria-expanded', String(!collapsed));
     ui.btnPanelToggle.textContent = collapsed ? '▸' : '▾';
     ui.btnPanelToggle.setAttribute('aria-label', collapsed ? 'Bedienpanel ausklappen' : 'Bedienpanel einklappen');
-  };
-}
-
-let windFlowLoading = false;
-const windFlowHint = ui.chkWindFlow?.closest('.row')?.querySelector('.hint');
-const windFlowHintText = windFlowHint?.textContent ?? '';
-if(ui.chkWindFlow){
-  ui.chkWindFlow.onchange = async ()=>{
-    if(ui.chkWindFlow.checked){
-      if(windFlowLoading) return;
-      windFlowLoading = true;
-      ui.chkWindFlow.disabled = true;
-      if(windFlowHint) windFlowHint.textContent = 'lädt…';
-      try{
-        await setWindFlow(L, map, true);
-      }catch(err){
-        console.warn('Windströmung konnte nicht geladen werden:', err);
-        alert('Windströmung konnte nicht geladen werden.');
-        ui.chkWindFlow.checked = false;
-      }finally{
-        windFlowLoading = false;
-        ui.chkWindFlow.disabled = false;
-        if(windFlowHint) windFlowHint.textContent = windFlowHintText;
-      }
-    }else{
-      setWindFlow(L, map, false);
-    }
   };
 }
 

--- a/js/warnings.js
+++ b/js/warnings.js
@@ -1,7 +1,19 @@
 // warnings.js
-import { DWD_WMS, DWD_WMS_LAYER, DWD_WARN_JSON, DWD_WFS } from './config.js';
+import { DWD_WMS, DWD_WMS_LAYER, DWD_WARN_JSON } from './config.js';
+
+const WARNING_LEVEL_COLORS = {
+  1: '#ffff00',
+  2: '#ffa500',
+  3: '#ff0000',
+  4: '#800080'
+};
+let mapInstance = null;
+let cachedWarnings = [];
+let filterUsesBounds = true;
 
 export function bind(L, map, ui){
+  mapInstance = map;
+
   // --- Pane für Warn-Layer (über Radar/Wolken) ---
   map.createPane('warnPane');
   map.getPane('warnPane').style.zIndex = 510;
@@ -22,17 +34,11 @@ export function bind(L, map, ui){
 
   const chkWarnInView = document.getElementById('chkWarnInView');
   if (chkWarnInView){
-    chkWarnInView.onchange = ()=> refreshList();
+    chkWarnInView.onchange = ()=> renderWarnings();
   }
-  // Bei Kartenbewegung neu filtern, wenn "nur im Kartenausschnitt" aktiv ist
+
   map.on('moveend', ()=>{
-    const box = document.getElementById('warnList');
-    if (box && box.style.display === 'block' && chkWarnInView?.checked){
-      refreshList();
-    } else {
-      // Banner trotzdem aktuell halten
-      refreshBannerOnly().catch(()=>{});
-    }
+    renderWarnings();
   });
 
   // --- WMS Toggle ---
@@ -96,38 +102,6 @@ export function bind(L, map, ui){
     return data; // hat Felder: { time, warnings: { <id>: [warnObj, ...], ... }, ... }
   }
 
-  // --- WFS: Warnflächen im aktuellen Kartenausschnitt (BBox) ---
-  async function fetchWarnAreasInView(){
-    // BBox in EPSG:4326 ermitteln (Leaflet liefert Bounds bereits als WGS84)
-    const b = map.getBounds();
-    const bbox = `${b.getWest()},${b.getSouth()},${b.getEast()},${b.getNorth()},EPSG:4326`;
-    const url = `${DWD_WFS}&bbox=${bbox}&srsName=EPSG:4326`;
-
-    const res = await fetch(url, { cache:'no-store' });
-    if (!res.ok) throw new Error('WFS BBOX failed: ' + res.status);
-    const geo = await res.json();
-    const features = Array.isArray(geo?.features) ? geo.features : [];
-    if (!features.length){
-      console.error('WFS BBOX returned no features for bbox:', bbox);
-      return { names: new Set(), ids: new Set(), featureCount: 0, bbox };
-    }
-
-    // Kandidaten für Regionsbezeichner/IDs sammeln
-    const names = new Set();
-    const ids   = new Set();
-    for (const f of features) {
-      const p = f.properties || {};
-      ['regionName','NAME','GEN','KREIS','KREIS_NAME','KREISNAME','AREADESC'].forEach(k=>{
-        if (typeof p[k] === 'string' && p[k].trim()) names.add(p[k].trim());
-      });
-      ['WARNCELLID','WARNCELL','RS','AGS','ID'].forEach(k=>{
-        const v = p[k];
-        if (v !== undefined && v !== null && String(v).trim()) ids.add(String(v).trim());
-      });
-    }
-    return { names, ids, featureCount: features.length, bbox };
-  }
-
   // --- Banner nur aktualisieren (ohne Liste zu rendern) ---
   async function refreshBannerOnly(){
     try{
@@ -146,86 +120,24 @@ export function bind(L, map, ui){
   async function refreshList(){
     try{
       const js   = await fetchWarningsJson();
-      let all    = Object.values(js?.warnings || {}).flat();
+      const all  = Object.values(js?.warnings || {}).flat();
 
-      // Bonus: nur Warnungen im aktuellen Kartenausschnitt
-      const onlyView = document.getElementById('chkWarnInView')?.checked;
-      if (onlyView){
-        try{
-          const { names, ids, featureCount, bbox } = await fetchWarnAreasInView();
-          if (featureCount > 0 && (names.size || ids.size)){
-            all = all.filter(w => {
-              const rn  = (w.regionName || '').trim();
-              const rid = String(w.regionId || w.regionID || w.region || w.warncellid || w.warncellID || '').trim();
-              return (rn && names.has(rn)) || (rid && ids.has(rid));
-            });
-          } else if (featureCount > 0){
-            console.warn('WFS features missing identifiers for bbox, skipping warning filter:', bbox);
-          } else {
-            console.error('No WFS features available to filter warnings for bbox:', bbox);
-          }
-        }catch(e){
-          console.warn('WFS filter failed, falling back to unfiltered warnings:', e);
-        }
-      }
-
-      // Banner zeigen/verstecken
       const banner = document.getElementById('noWarnBanner');
       if (banner) banner.style.display = all.length ? 'none' : 'block';
 
-      // Wenn Liste nicht sichtbar, hier aufhören
-      const box = document.getElementById('warnList');
-      if (!box || box.style.display !== 'block') return;
-
-      // Liste rendern
-      const root = document.getElementById('warnItems');
-      if (!root) return;
-      root.innerHTML = '';
-
-      if (!all.length){
-        root.innerHTML = `<div class="hint">Derzeit keine aktiven Warnungen${onlyView ? ' im Kartenausschnitt' : ''}.</div>`;
-        return;
-      }
-
-      // Sortierung: höchste Stufe zuerst
-      all.sort((a,b)=>(Number(b.level||0) - Number(a.level||0)));
-
-      const COLORS = {1:'#ffff00', 2:'#ffa500', 3:'#ff0000', 4:'#800080'};
-      const EMO    = {1:'🟡',      2:'🟠',      3:'🔴',      4:'🟣'     };
-
-      for (const w of all){
-        const lvl   = Number(w.level || 0);
-        const col   = COLORS[lvl] || '#ddd';
-        const emo   = EMO[lvl]    || '🟦';
-        const head  = w.headline || w.event || 'Wetterwarnung';
-        const start = w.start ? new Date(w.start).toLocaleString() : '';
-        const end   = w.end   ? new Date(w.end).toLocaleString()   : '';
-        const txt   = (w.description || w.text || '').replace(/\n+/g,'<br>');
-        const region= (w.regionName || '').trim();
-
-        const div = document.createElement('div');
-        div.className = 'warn-card';
-        div.style.borderLeftColor = col;
-        div.innerHTML = `
-          <div style="display:flex;justify-content:space-between;gap:8px;align-items:baseline;">
-            <b>${emo} ${head}</b>
-            <span class="hint">Stufe ${lvl}${region ? ' • ' + region : ''}</span>
-          </div>
-          <div class="hint" style="margin:2px 0 6px 0">${start}${end ? ' – ' + end : ''}</div>
-          <div>${txt}</div>
-        `;
-        root.appendChild(div);
-      }
-
+      renderWarnings(all);
     }catch(e){
       console.warn('DWD warnings failed:', e);
+      cachedWarnings = [];
+
       const banner = document.getElementById('noWarnBanner');
       if (banner) banner.style.display = 'block';
 
-      const box = document.getElementById('warnList');
-      if (box && box.style.display === 'block'){
-        const root = document.getElementById('warnItems');
-        if (root) root.innerHTML = '<div class="hint">Warnungen konnten nicht geladen werden.</div>';
+      const root = document.getElementById('warnItems');
+      if (root){
+        root.style.maxHeight = '300px';
+        root.style.overflowY = 'auto';
+        root.innerHTML = '<div class="hint">Warnungen konnten nicht geladen werden.</div>';
       }
     }
   }
@@ -237,4 +149,216 @@ export function bind(L, map, ui){
   refreshBannerOnly();
   // Liste erst laden, wenn aktiv
   if (ui.chkWarnList?.checked) refreshList();
+}
+
+export function renderWarnings(warnings){
+  if (Array.isArray(warnings)){
+    cachedWarnings = warnings.filter(w => w && typeof w === 'object');
+  }
+
+  if (!mapInstance){
+    return [];
+  }
+
+  const bounds = mapInstance.getBounds();
+  const useBounds = isBoundsFilterActive();
+  filterUsesBounds = useBounds;
+
+  const source = Array.isArray(cachedWarnings) ? cachedWarnings : [];
+  const filtered = useBounds
+    ? source.filter(w => isWarningInsideBounds(w, bounds))
+    : source.slice();
+
+  filtered.sort((a, b) => Number(b?.level ?? 0) - Number(a?.level ?? 0));
+
+  updateWarningList(filtered);
+  return filtered;
+}
+
+export function createWarningCard(warning){
+  const level = Number(warning?.level ?? warning?.severity ?? 0);
+  const color = WARNING_LEVEL_COLORS[level] || '#b3b3b3';
+
+  const card = document.createElement('div');
+  card.className = 'warn-card';
+  card.dataset.level = Number.isFinite(level) && level > 0 ? String(level) : '';
+  card.style.borderLeft = `6px solid ${color}`;
+  card.style.padding = '8px 12px';
+  card.style.margin = '0 0 8px 0';
+
+  const title = document.createElement('div');
+  title.className = 'warn-card__headline';
+  title.textContent = warning?.headline || warning?.event || 'Wetterwarnung';
+  card.appendChild(title);
+
+  const metaParts = [];
+  if (Number.isFinite(level) && level > 0){
+    metaParts.push(`Stufe ${level}`);
+  }
+  const region = (warning?.regionName || warning?.area || warning?.region || '').trim();
+  if (region){
+    metaParts.push(region);
+  }
+  const timeframe = formatTimeRange(warning?.start, warning?.end);
+  if (timeframe){
+    metaParts.push(timeframe);
+  }
+
+  if (metaParts.length){
+    const meta = document.createElement('div');
+    meta.className = 'warn-card__meta hint';
+    meta.textContent = metaParts.join(' • ');
+    card.appendChild(meta);
+  }
+
+  const description = (warning?.description || warning?.text || '').trim();
+  if (description){
+    const desc = document.createElement('div');
+    desc.className = 'warn-card__description';
+    appendTextWithBreaks(desc, description);
+    card.appendChild(desc);
+  }
+
+  return card;
+}
+
+export function updateWarningList(filtered){
+  const root = document.getElementById('warnItems');
+  if (!root) return;
+
+  root.style.maxHeight = '300px';
+  root.style.overflowY = 'auto';
+  root.innerHTML = '';
+
+  if (!Array.isArray(filtered) || filtered.length === 0){
+    const empty = document.createElement('div');
+    empty.className = 'warn-empty hint';
+    empty.textContent = filterUsesBounds
+      ? 'Keine Warnungen im aktuellen Kartenausschnitt'
+      : 'Derzeit keine aktiven Warnungen';
+    root.appendChild(empty);
+    return;
+  }
+
+  root.scrollTop = 0;
+  filtered.forEach(w => {
+    root.appendChild(createWarningCard(w));
+  });
+}
+
+function appendTextWithBreaks(target, text){
+  const parts = text.split(/\n+/).filter(part => part.trim().length > 0);
+  if (!parts.length){
+    target.textContent = text;
+    return;
+  }
+
+  parts.forEach((part, idx) => {
+    target.appendChild(document.createTextNode(part.trim()));
+    if (idx < parts.length - 1){
+      target.appendChild(document.createElement('br'));
+    }
+  });
+}
+
+function formatTimeRange(start, end){
+  const startStr = formatTimestamp(start);
+  const endStr = formatTimestamp(end);
+
+  if (startStr && endStr){
+    return `${startStr} – ${endStr}`;
+  }
+  return startStr || endStr || '';
+}
+
+function formatTimestamp(value){
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString();
+}
+
+function isWarningInsideBounds(warning, bounds){
+  const coords = extractCoordinates(warning);
+  if (!coords) return false;
+
+  const { lat, lon } = coords;
+  const south = bounds.getSouth();
+  const north = bounds.getNorth();
+  const west = bounds.getWest();
+  const east = bounds.getEast();
+
+  if (east < west){
+    const withinLon = lon >= west || lon <= east;
+    return withinLon && lat >= south && lat <= north;
+  }
+
+  return lat >= south && lat <= north && lon >= west && lon <= east;
+}
+
+function extractCoordinates(warning){
+  if (!warning || typeof warning !== 'object') return null;
+
+  const lat = pickNumeric([
+    warning.lat,
+    warning.latitude,
+    warning?.latLng?.lat,
+    warning?.latlng?.lat,
+    warning?.position?.lat,
+    warning?.coordinates?.[1],
+    warning?.coord?.[1],
+    warning?.geometry?.coordinates?.[1],
+    warning?.geometry?.coordinates?.[0]?.[1],
+    Array.isArray(warning?.geometry?.geometries)
+      ? warning.geometry.geometries[0]?.coordinates?.[1]
+      : undefined
+  ]);
+
+  const lon = pickNumeric([
+    warning.lon,
+    warning.lng,
+    warning.longitude,
+    warning?.latLng?.lng,
+    warning?.latlng?.lng,
+    warning?.position?.lng,
+    warning?.position?.lon,
+    warning?.coordinates?.[0],
+    warning?.coord?.[0],
+    warning?.geometry?.coordinates?.[0],
+    warning?.geometry?.coordinates?.[0]?.[0],
+    Array.isArray(warning?.geometry?.geometries)
+      ? warning.geometry.geometries[0]?.coordinates?.[0]
+      : undefined
+  ]);
+
+  if (lat === null || lon === null) return null;
+  return { lat, lon };
+}
+
+function pickNumeric(candidates){
+  for (const value of candidates){
+    const numeric = parseCoordinate(value);
+    if (numeric !== null) return numeric;
+  }
+  return null;
+}
+
+function parseCoordinate(value){
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'string'){
+    const normalized = value.trim().replace(',', '.');
+    if (!normalized){
+      return null;
+    }
+    const num = Number(normalized);
+    return Number.isFinite(num) ? num : null;
+  }
+
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function isBoundsFilterActive(){
+  const chk = document.getElementById('chkWarnInView');
+  return !chk || chk.checked;
 }


### PR DESCRIPTION
## Summary
- re-render the warning list whenever the Leaflet view changes so cached datasets are filtered against the current bounds
- add `renderWarnings`, `createWarningCard`, and `updateWarningList` helpers that build colored cards and manage the viewport-empty message
- introduce formatting and coordinate extraction helpers so warning descriptions, timestamps, and map positions render cleanly while keeping the list scrollable
- bind the wind flow checkbox to a leaflet-velocity overlay that validates `/wind/current.json`, loads data on demand, and reuses the layer when toggled off and on again

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d014ecedfc8330a48b09fbd35920a6