### PR TITLE
Add DWD satellite WMS proxy with robust upstream failure handling and frontend fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ systemctl enable --now wetterradar-noaa-wind.timer
 - Auf dem Server sollten Schreibrechte für den Fetcher auf `/var/www/wetterradar/wind/current.json` bestehen.
 - Die Beispiel-Nginx-Config (siehe `etc/nginx/sites-available/wetter.domain.tld`) enthält einen Location-Block für `/wind/`, der Caching + CORS-Header setzt.
 - RainViewer `weather-maps.json` wird serverseitig via Nginx unter `/rainviewer/weather-maps.json` auf `https://api.rainviewer.com/public/weather-maps.json` proxied, damit das Frontend sie same-origin laden kann.
+- Für den DWD-Satellitenlayer sollte `/dwd/sat/wms` auf `https://maps.dwd.de/geoserver/dwd/ows` zeigen (WMS über `request=GetMap`) und bei 5xx-Fehlern ein valides Bild (z. B. `empty_gif`) ausliefern, damit Tile-Rendering im Browser stabil bleibt.
 
 ## Lokale Entwicklung & Kurztest
 

--- a/etc/nginx/sites-available/wetter.domain.tld
+++ b/etc/nginx/sites-available/wetter.domain.tld
@@ -102,13 +102,23 @@ server {
 
 
     # DWD Satellit WMS Proxy (same-origin für Leaflet WMS)
+    # Hinweis:
+    # - DWD liefert WMS stabil über /geoserver/dwd/ows
+    # - Query-String wird 1:1 weitergereicht
+    # - bei Upstream-Fehlern liefern wir ein valides 1x1 GIF zurück
     location = /dwd/sat/wms {
-        proxy_pass https://maps.dwd.de/geoserver/dwd/wms$is_args$args;
+        proxy_pass https://maps.dwd.de/geoserver/dwd/ows?$args;
         proxy_set_header Host maps.dwd.de;
         proxy_ssl_server_name on;
+        proxy_set_header Accept "image/*,*/*;q=0.8";
+        proxy_http_version 1.1;
+
+        proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+        proxy_next_upstream_tries 2;
         proxy_connect_timeout 5s;
         proxy_read_timeout 20s;
         proxy_send_timeout 20s;
+
         proxy_intercept_errors on;
         error_page 500 502 503 504 =200 /__dwd_empty_tile.gif;
         add_header Access-Control-Allow-Origin * always;

--- a/js/satellite.js
+++ b/js/satellite.js
@@ -29,16 +29,12 @@ export function toggle(L, map, on, opacity=0.7){
     usingFallbackHost = false;
     layer = createLayer(L, DWD_SAT_WMS, opacity).addTo(map);
 
-    // Falls kein same-origin Proxy vorhanden ist (z.B. lokale Entwicklung),
+    // Wenn der same-origin Proxy ausfällt (z.B. 5xx vom Upstream),
     // wechsle automatisch auf den direkten DWD-Endpunkt.
-    // In Produktion (HTTPS + nicht localhost) bleibt der Proxy aktiv, damit
-    // Browser-Sicherheitsmechanismen (z.B. ORB/CSP) nicht durch Cross-Origin-
-    // Requests unnötig Fehler produzieren.
+    // Leaflet lädt Kacheln als <img>, daher ist hierfür kein CORS-Read nötig.
+    // Damit bleibt das Satelliten-Layer auch bei Proxy-/Nginx-Störungen nutzbar.
     layer.once('tileerror', ()=>{
       if(!layer || usingFallbackHost) return;
-      const host = (typeof window !== 'undefined' && window.location && window.location.hostname) || '';
-      const isLocalhost = host === 'localhost' || host === '127.0.0.1' || host === '::1';
-      if(!isLocalhost) return;
       map.removeLayer(layer);
       usingFallbackHost = true;
       layer = createLayer(L, DWD_SAT_WMS_FALLBACK, opacity).addTo(map);

--- a/wetter_nginx.conf
+++ b/wetter_nginx.conf
@@ -34,4 +34,29 @@ server {
         root /var/www/wetterradar;
         index index.html;
     }
+
+    # DWD Satellit WMS Proxy (same-origin)
+    location = /dwd/sat/wms {
+        proxy_pass https://maps.dwd.de/geoserver/dwd/ows?$args;
+        proxy_set_header Host maps.dwd.de;
+        proxy_ssl_server_name on;
+        proxy_set_header Accept "image/*,*/*;q=0.8";
+        proxy_http_version 1.1;
+        proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+        proxy_next_upstream_tries 2;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 20s;
+        proxy_send_timeout 20s;
+        proxy_intercept_errors on;
+        error_page 500 502 503 504 =200 /__dwd_empty_tile.gif;
+        add_header Access-Control-Allow-Origin * always;
+        add_header Cache-Control "public, max-age=60, stale-while-revalidate=120" always;
+    }
+
+    location = /__dwd_empty_tile.gif {
+        internal;
+        empty_gif;
+        add_header Content-Type image/gif always;
+        add_header Cache-Control "no-store" always;
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide a same-origin proxy for the DWD satellite WMS so the frontend can load tiles reliably under the site domain and avoid cross-origin issues. 
- Ensure tile rendering remains stable when the upstream DWD service returns 5xx errors by returning a valid tiny image instead of HTML error pages. 
- Allow the frontend to automatically fall back to the direct DWD endpoint when the proxy is unavailable or returns tile errors so local development and degraded operation remain usable. 

### Description
- Added a `/dwd/sat/wms` proxy location to `etc/nginx/sites-available/wetter.domain.tld` and `wetter_nginx.conf` that proxies to `https://maps.dwd.de/geoserver/dwd/ows?$args`, sets `Host` and `Accept` headers, configures timeouts and `proxy_next_upstream`, and returns a valid 1x1 GIF on upstream 5xx errors via `error_page ... =200 /__dwd_empty_tile.gif`. 
- Added an internal `location = /__dwd_empty_tile.gif` that serves `empty_gif` with correct `Content-Type` and `Cache-Control`. 
- Updated `js/satellite.js` to remove the previous localhost-only condition and to switch to `DWD_SAT_WMS_FALLBACK` on `tileerror`, allowing the layer to keep working if the same-origin proxy fails. 
- Documented the proxy requirement and behavior in `README.md` and added guidance that `/dwd/sat/wms` should point to the DWD geoserver and return a valid image on 5xx errors. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e211f2dba083279d8263e48672829b)