### PR TITLE
Use direct DWD WMS endpoint for satellite tiles

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -19,7 +19,8 @@ export const DWD_WMS_LAYER = 'dwd:Warnungen_Landkreise';
 export const DWD_WARN_JSON = '/dwd/warnings.json';
 export const DWD_WFS = 'https://maps.dwd.de/geoserver/dwd/ows?service=WFS&version=2.0.0&request=GetFeature&typeNames=dwd:Warnungen_Landkreise&outputFormat=application/json';
 
-// DWD Satellitendaten (WMS) – über same-origin Proxy, damit CSP/CORS sauber funktioniert.
-// Fallback direkt auf maps.dwd.de erfolgt in satellite.js, falls kein Proxy konfiguriert ist.
-export const DWD_SAT_WMS = '/dwd/sat/wms?';
+// DWD Satellitendaten (WMS): primär direkt von maps.dwd.de laden.
+// Hintergrund: wenn ein Reverse-Proxy (z. B. /dwd/sat/wms) Upstream-502 liefert,
+// bleiben Satellitenkacheln trotzdem verfügbar und der Layer fällt nicht aus.
+export const DWD_SAT_WMS = 'https://maps.dwd.de/geoserver/dwd/wms?';
 export const DWD_SAT_LAYER = 'dwd:SAT_WELT_KOMPOSIT';


### PR DESCRIPTION
### Motivation
- Access logs showed repeated `502` responses from the local `/dwd/sat/wms` proxy which caused missing satellite tiles, so the primary source should avoid the flaky proxy.

### Description
- Updated `js/config.js` to set `DWD_SAT_WMS` to `https://maps.dwd.de/geoserver/dwd/wms?` instead of `/dwd/sat/wms?` and extended the inline comment explaining the reason.

### Testing
- Committed the change and verified the file contents with `nl -ba js/config.js`, which succeeded.
- Attempted an automated `curl` check against the DWD endpoints, but the execution environment returned `403` (CONNECT tunnel failed), so a live upstream fetch could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7512580f483279bb7c993c5fdd8bb)