### PR TITLE
Use DWD native WMS endpoint, improve nginx proxy and client fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ systemctl enable --now wetterradar-noaa-wind.timer
 - Auf dem Server sollten Schreibrechte für den Fetcher auf `/var/www/wetterradar/wind/current.json` bestehen.
 - Die Beispiel-Nginx-Config (siehe `etc/nginx/sites-available/wetter.domain.tld`) enthält einen Location-Block für `/wind/`, der Caching + CORS-Header setzt.
 - RainViewer `weather-maps.json` wird serverseitig via Nginx unter `/rainviewer/weather-maps.json` auf `https://api.rainviewer.com/public/weather-maps.json` proxied, damit das Frontend sie same-origin laden kann.
-- Für den DWD-Satellitenlayer sollte `/dwd/sat/wms` auf `https://maps.dwd.de/geoserver/dwd/ows` zeigen (WMS über `request=GetMap`) und bei 5xx-Fehlern ein valides Bild (z. B. `empty_gif`) ausliefern, damit Tile-Rendering im Browser stabil bleibt.
+- Für den DWD-Satellitenlayer sollte `/dwd/sat/wms` auf `https://maps.dwd.de/geoserver/dwd/wms` zeigen und bei 5xx-Fehlern ein valides Bild (z. B. `empty_gif`) ausliefern, damit Tile-Rendering im Browser stabil bleibt.
 
 ## Lokale Entwicklung & Kurztest
 

--- a/etc/nginx/sites-available/wetter.domain.tld
+++ b/etc/nginx/sites-available/wetter.domain.tld
@@ -103,15 +103,17 @@ server {
 
     # DWD Satellit WMS Proxy (same-origin für Leaflet WMS)
     # Hinweis:
-    # - DWD liefert WMS stabil über /geoserver/dwd/ows
+    # - DWD Satellit über den nativen WMS-Endpunkt /geoserver/dwd/wms
     # - Query-String wird 1:1 weitergereicht
     # - bei Upstream-Fehlern liefern wir ein valides 1x1 GIF zurück
     location = /dwd/sat/wms {
-        proxy_pass https://maps.dwd.de/geoserver/dwd/ows?$args;
+        proxy_pass https://maps.dwd.de/geoserver/dwd/wms$is_args$args;
         proxy_set_header Host maps.dwd.de;
         proxy_ssl_server_name on;
+        proxy_ssl_name maps.dwd.de;
         proxy_set_header Accept "image/*,*/*;q=0.8";
         proxy_http_version 1.1;
+        proxy_set_header Connection "";
 
         proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
         proxy_next_upstream_tries 2;

--- a/js/config.js
+++ b/js/config.js
@@ -19,7 +19,8 @@ export const DWD_WMS_LAYER = 'dwd:Warnungen_Landkreise';
 export const DWD_WARN_JSON = '/dwd/warnings.json';
 export const DWD_WFS = 'https://maps.dwd.de/geoserver/dwd/ows?service=WFS&version=2.0.0&request=GetFeature&typeNames=dwd:Warnungen_Landkreise&outputFormat=application/json';
 
-// DWD Satellitendaten (WMS) – über same-origin Proxy, damit CSP/CORS sauber funktioniert.
-// Fallback direkt auf maps.dwd.de erfolgt in satellite.js, falls kein Proxy konfiguriert ist.
-export const DWD_SAT_WMS = '/dwd/sat/wms?';
+// DWD Satellitendaten (WMS): primär direkt von maps.dwd.de laden.
+// Hintergrund: wenn ein Reverse-Proxy (z. B. /dwd/sat/wms) Upstream-502 liefert,
+// bleiben Satellitenkacheln trotzdem verfügbar und der Layer fällt nicht aus.
+export const DWD_SAT_WMS = 'https://maps.dwd.de/geoserver/dwd/wms?';
 export const DWD_SAT_LAYER = 'dwd:SAT_WELT_KOMPOSIT';

--- a/js/satellite.js
+++ b/js/satellite.js
@@ -2,6 +2,7 @@
 import { DWD_SAT_WMS, DWD_SAT_LAYER } from './config.js';
 
 const DWD_SAT_WMS_FALLBACK = 'https://maps.dwd.de/geoserver/dwd/wms?';
+const DWD_SAT_WMS_DIRECT = 'https://maps.dwd.de/geoserver/dwd/wms?';
 
 let layer = null;
 let usingFallbackHost = false;
@@ -23,11 +24,21 @@ function createLayer(L, url, opacity){
   });
 }
 
+function resolvePrimaryWmsUrl(){
+  // Falls eine ältere Konfiguration noch auf den lokalen Proxy zeigt
+  // (z. B. /dwd/sat/wms) und dieser nicht existiert (404), erzwingen wir
+  // direkt den DWD-Host als Primärquelle.
+  if (typeof DWD_SAT_WMS === 'string' && /^https?:\/\//i.test(DWD_SAT_WMS)){
+    return DWD_SAT_WMS;
+  }
+  return DWD_SAT_WMS_DIRECT;
+}
+
 export function toggle(L, map, on, opacity=0.7){
   if(on){
     if(layer) map.removeLayer(layer);
     usingFallbackHost = false;
-    layer = createLayer(L, DWD_SAT_WMS, opacity).addTo(map);
+    layer = createLayer(L, resolvePrimaryWmsUrl(), opacity).addTo(map);
 
     // Wenn der same-origin Proxy ausfällt (z.B. 5xx vom Upstream),
     // wechsle automatisch auf den direkten DWD-Endpunkt.

--- a/wetter_nginx.conf
+++ b/wetter_nginx.conf
@@ -37,11 +37,14 @@ server {
 
     # DWD Satellit WMS Proxy (same-origin)
     location = /dwd/sat/wms {
-        proxy_pass https://maps.dwd.de/geoserver/dwd/ows?$args;
+        # Direkter WMS-Endpunkt statt /ows, um Upstream-Gateway-Probleme zu vermeiden.
+        proxy_pass https://maps.dwd.de/geoserver/dwd/wms$is_args$args;
         proxy_set_header Host maps.dwd.de;
         proxy_ssl_server_name on;
+        proxy_ssl_name maps.dwd.de;
         proxy_set_header Accept "image/*,*/*;q=0.8";
         proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
         proxy_next_upstream_tries 2;
         proxy_connect_timeout 5s;


### PR DESCRIPTION
### Motivation
- Avoid upstream gateway issues with the DWD geoserver by using the native WMS endpoint instead of the generic `ows` entrypoint. 
- Ensure the satellite layer remains available even when a same-origin proxy fails. 
- Update documentation and server configs to reflect the more reliable endpoint and proxy behavior.

### Description
- Updated docs in `README.md` to recommend `https://maps.dwd.de/geoserver/dwd/wms` for the DWD satellite layer proxy. 
- Changed nginx proxy configuration in `etc/nginx/sites-available/wetter.domain.tld` and `wetter_nginx.conf` to proxy to `https://maps.dwd.de/geoserver/dwd/wms` and added `proxy_ssl_name maps.dwd.de` and `proxy_set_header Connection ""` plus other proxy tuning. 
- Switched client defaults in `js/config.js` to use the direct DWD WMS URL `https://maps.dwd.de/geoserver/dwd/wms?` and clarified behavior in comments. 
- Enhanced `js/satellite.js` by adding `DWD_SAT_WMS_DIRECT`, a `resolvePrimaryWmsUrl()` helper to prefer an absolute URL or fall back to the direct host, and wiring that into the layer creation logic while keeping the existing tile-error fallback to the alternate host.

### Testing
- No automated tests were added or executed for these configuration and client changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7512580f483279bb7c993c5fdd8bb)