### PR TITLE
Restore DWD satellite imagery layer with WMS fallbacks and attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wetterradar (Leaflet + RainViewer + NOAA GFS + DWD)
 
-Interaktive Wetterkarte mit Radar- und Satellitenanimation, Wind-Partikelfeld und DWD-Warngebieten (CAP-Polygone). Leichtgewichtig mit Leaflet und Vanilla-JS.
+Interaktive Wetterkarte mit Radar, DWD/EUMETSAT-Satellitenbild, Wind-Partikelfeld und DWD-Warngebieten (CAP-Polygone). Leichtgewichtig mit Leaflet und Vanilla-JS.
 
 Nutzbar unter https://wetter.larsmueller.net
 
@@ -12,8 +12,8 @@ https://de.liberapay.com/Esmuellerthier/
 
 - **Niederschlagsradar (RainViewer)**
   *Vergangenheit + Nowcast* (kurzfristige Vorhersage), animiert über Time-Slider.
-- **IR-Satellitenbilder (RainViewer)**
-  Synchronisiert zum Radar-Zeitpunkt; ein-/ausblendbar, Opazität regelbar.
+- **Satellitenbild (DWD/EUMETSAT)**
+  Aktuelles Meteosat-Europabild aus dem DWD-GeoServer (`dwd:Satellite_meteosat_1km_euat_rgb_day_hrv_and_night_ir108_3h`); ein-/ausblendbar, Opazität regelbar. Der lokale Proxy `/dwd/sat/wms` wird zuerst genutzt, danach direkte DWD-Fallbacks.
 - **Wind-Partikelfeld (leaflet-velocity)**
   Vektorfeld aus **NOAA/NCEP GFS 1.0° (10 m Wind)** via NOMADS-Filter, als animierte Partikel (east/north-Komponenten).
 - **DWD-Warnungen**
@@ -23,11 +23,12 @@ https://de.liberapay.com/Esmuellerthier/
 
 ## Datenquellen
 
-- **RainViewer Weather Maps API** – Radar/Satellit (Tiles + Frames)
+- **RainViewer Weather Maps API** – Niederschlagsradar (Tiles + Frames)
+- **DWD/EUMETSAT Satellit** – Meteosat-Europabild per DWD-WMS; Open-Data-Rohprodukte liegen ergänzend unter `https://opendata.dwd.de/weather/satellite/`
 - **NOAA/NCEP GFS via NOMADS** – Windgeschwindigkeit/-richtung (10 m)
 - **DWD CAP/JSON** – amtliche Warnungen (Polygone + Metadaten)
 
-> Hinweis zu Limits (Stand 2025): RainViewer Free begrenzt Zoom (≤ 10) und Nowcast-Dauer; IR-Satellit wird von RainViewer mittelfristig eingeschränkt. Prüfe ggf. die aktuellen Nutzungsbedingungen/Docs.
+> Hinweis zu Satellitendaten: Der Frontend-Layer nutzt den DWD-WMS als Bild-/Darstellungsdienst. Die Open-Data-Verzeichnisse (`/weather/satellite/clouds/`, `/weather/satellite/radiation/`) stellen Rohprodukte wie komprimierte NetCDF-Dateien bereit und sind eher für serverseitige Verarbeitung geeignet. Bei Weiterverarbeitung bitte die Quellenangabe „EUMETSAT / DWD“ bzw. „Datenbasis: Deutscher Wetterdienst (DWD)“ beibehalten.
 
 ## Verzeichnis­struktur
 
@@ -37,7 +38,7 @@ https://de.liberapay.com/Esmuellerthier/
 │ ├─ app.js # Bootstrapping, Konfiguration, Wiring der Module
 │ ├─ map.js # Leaflet-Karte (OSM)
 │ ├─ radar.js # RainViewer Radar + Animation/Timeline
-│ ├─ clouds.js # IR-Satellit (RainViewer), Zeitsync + Throttle
+│ ├─ satellite.js # DWD/EUMETSAT-Satellitenbild per WMS + Fallbacks
 │ ├─ wind_particles.js # leaflet-velocity + NOAA-GFS-Sampling
 │ ├─ warnings.js # DWD JSON-Liste + CAP-Polygone als Overlays
 │ └─ utils.js # Helfer (Fetch/Proxy, DOM, Formatierungen, Legend)
@@ -77,7 +78,7 @@ systemctl enable --now wetterradar-noaa-wind.timer
 - Auf dem Server sollten Schreibrechte für den Fetcher auf `/var/www/wetterradar/wind/current.json` bestehen.
 - Die Beispiel-Nginx-Config (siehe `etc/nginx/sites-available/wetter.domain.tld`) enthält einen Location-Block für `/wind/`, der Caching + CORS-Header setzt.
 - RainViewer `weather-maps.json` wird serverseitig via Nginx unter `/rainviewer/weather-maps.json` auf `https://api.rainviewer.com/public/weather-maps.json` proxied, damit das Frontend sie same-origin laden kann.
-- Für den DWD-Satellitenlayer sollte `/dwd/sat/wms` auf `https://maps.dwd.de/geoserver/dwd/wms` zeigen und bei 5xx-Fehlern ein valides Bild (z. B. `empty_gif`) ausliefern, damit Tile-Rendering im Browser stabil bleibt.
+- Für den DWD-Satellitenlayer sollte `/dwd/sat/wms` auf `https://maps.dwd.de/geoserver/wms` zeigen und bei 5xx-Fehlern ein valides Bild (z. B. `empty_gif`) ausliefern, damit Tile-Rendering im Browser stabil bleibt. Falls der Proxy nicht verfügbar ist, fällt das Frontend automatisch auf `maps.dwd.de` und `brz-maps.dwd.de` zurück.
 
 ## Lokale Entwicklung & Kurztest
 

--- a/etc/nginx/sites-available/wetter.domain.tld
+++ b/etc/nginx/sites-available/wetter.domain.tld
@@ -103,13 +103,13 @@ server {
 
     # DWD Satellit WMS Proxy (same-origin für Leaflet WMS)
     # Hinweis:
-    # - DWD Satellit über den nativen WMS-Endpunkt /geoserver/dwd/wms
+    # - DWD Satellit über den nativen WMS-Endpunkt /geoserver/wms
     # - Query-String wird 1:1 weitergereicht
     # - bei Upstream-Fehlern liefern wir ein valides 1x1 GIF zurück
     location = /dwd/sat/wms {
         # Kein Variablenanteil im Upstream-Host, damit kein separater `resolver`
         # erforderlich ist (sonst: "no resolver defined to resolve maps.dwd.de").
-        proxy_pass https://maps.dwd.de/geoserver/dwd/wms?$args;
+        proxy_pass https://maps.dwd.de/geoserver/wms?$args;
         proxy_set_header Host maps.dwd.de;
         proxy_ssl_server_name on;
         proxy_ssl_name maps.dwd.de;

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
         <span id="lblPrecipStatus" class="badge" style="display:none"></span>
       </div>
       <div class="row">
-        <label for="chkClouds">Wolken (DWD Satellit)</label>
+        <label for="chkClouds">Satellit (DWD/EUMETSAT)</label>
         <input type="checkbox" id="chkClouds">
         <input id="rngClouds" type="range" min="0.2" max="1" step="0.05" value="0.7" class="grow">
         <span id="lblClouds">70%</span>
@@ -122,7 +122,7 @@
     </div>
   </div>
 
-  <footer class="footer">Radar: RainViewer • Satellit: DWD • Wind: Open-Meteo • OSM © Mitwirkende</footer>
+  <footer class="footer">Radar: RainViewer • Satellit: EUMETSAT / DWD (CC BY 4.0) • Wind: Open-Meteo • OSM © Mitwirkende</footer>
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
           integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin></script>

--- a/js/config.js
+++ b/js/config.js
@@ -19,8 +19,13 @@ export const DWD_WMS_LAYER = 'dwd:Warnungen_Landkreise';
 export const DWD_WARN_JSON = '/dwd/warnings.json';
 export const DWD_WFS = 'https://maps.dwd.de/geoserver/dwd/ows?service=WFS&version=2.0.0&request=GetFeature&typeNames=dwd:Warnungen_Landkreise&outputFormat=application/json';
 
-// DWD Satellitendaten (WMS): primär direkt von maps.dwd.de laden.
-// Hintergrund: wenn ein Reverse-Proxy (z. B. /dwd/sat/wms) Upstream-502 liefert,
-// bleiben Satellitenkacheln trotzdem verfügbar und der Layer fällt nicht aus.
-export const DWD_SAT_WMS = 'https://maps.dwd.de/geoserver/dwd/wms?';
-export const DWD_SAT_LAYER = 'dwd:SAT_WELT_KOMPOSIT';
+// DWD Satellitenbilder (WMS): lokaler Proxy zuerst, danach direkte DWD-Hosts.
+// Der Browser-Layer nutzt den DWD-GeoServer als Darstellungsdienst; die
+// Open-Data-Verzeichnisse unter opendata.dwd.de enthalten dazu ergänzend
+// Rohprodukte wie NetCDF-Dateien, aber keine direkt nutzbaren Leaflet-Kacheln.
+export const DWD_SAT_WMS = '/dwd/sat/wms?';
+export const DWD_SAT_WMS_FALLBACKS = [
+  'https://maps.dwd.de/geoserver/wms?',
+  'https://brz-maps.dwd.de/geoserver/wms?',
+];
+export const DWD_SAT_LAYER = 'dwd:Satellite_meteosat_1km_euat_rgb_day_hrv_and_night_ir108_3h';

--- a/js/satellite.js
+++ b/js/satellite.js
@@ -1,16 +1,38 @@
-// Satellitenbilder via DWD WMS (ersetzt RainViewer IR, das seit 2025 eingestellt ist)
-import { DWD_SAT_WMS, DWD_SAT_LAYER } from './config.js';
+// Satellitenbilder via DWD-WMS.
+// Die frei sichtbaren DWD-Satellitenprodukte basieren auf EUMETSAT-Daten und
+// werden als OGC-WMS-Bildlayer veröffentlicht. Die Open-Data-Verzeichnisse
+// unter opendata.dwd.de enthalten ergänzend Rohprodukte (z. B. NetCDF), die für
+// den Browser-Layer nicht direkt als Kartenkacheln geeignet sind.
+import { DWD_SAT_LAYER, DWD_SAT_WMS, DWD_SAT_WMS_FALLBACKS } from './config.js';
 
-const DWD_SAT_WMS_FALLBACK = 'https://maps.dwd.de/geoserver/dwd/wms?';
-const DWD_SAT_WMS_DIRECT = 'https://maps.dwd.de/geoserver/dwd/wms?';
+const DEFAULT_WMS_ENDPOINTS = [
+  'https://maps.dwd.de/geoserver/wms?',
+  'https://brz-maps.dwd.de/geoserver/wms?',
+];
 
 let layer = null;
-let usingFallbackHost = false;
+let endpointIndex = 0;
+let endpoints = [];
 
 export async function loadSatellite(){
-  // DWD WMS benötigt kein Vorab-Laden von Frames –
-  // der Layer zeigt immer den aktuellsten Stand.
+  // DWD WMS benötigt kein Vorab-Laden von Frames – der Layer zeigt immer den
+  // neuesten vom DWD veröffentlichten Zeitschritt des Satellitenprodukts.
+  endpoints = buildEndpointList(DWD_SAT_WMS, DWD_SAT_WMS_FALLBACKS);
   return [];
+}
+
+function normalizeWmsUrl(url){
+  if (typeof url !== 'string') return null;
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  return trimmed.includes('?') ? trimmed : `${trimmed}?`;
+}
+
+function buildEndpointList(primary, fallbacks = []){
+  const candidates = [primary, ...(Array.isArray(fallbacks) ? fallbacks : []), ...DEFAULT_WMS_ENDPOINTS]
+    .map(normalizeWmsUrl)
+    .filter(Boolean);
+  return [...new Set(candidates)];
 }
 
 function createLayer(L, url, opacity){
@@ -20,47 +42,48 @@ function createLayer(L, url, opacity){
     transparent: true,
     pane: 'cloudPane',
     opacity,
-    attribution: 'Satellit © DWD'
+    version: '1.1.1',
+    attribution: 'Satellit: EUMETSAT / DWD (CC BY 4.0)'
   });
 }
 
-function resolvePrimaryWmsUrl(){
-  // Falls eine ältere Konfiguration noch auf den lokalen Proxy zeigt
-  // (z. B. /dwd/sat/wms) und dieser nicht existiert (404), erzwingen wir
-  // direkt den DWD-Host als Primärquelle.
-  if (typeof DWD_SAT_WMS === 'string' && /^https?:\/\//i.test(DWD_SAT_WMS)){
-    return DWD_SAT_WMS;
-  }
-  return DWD_SAT_WMS_DIRECT;
+function addLayerWithFallback(L, map, opacity){
+  if (!endpoints.length) endpoints = buildEndpointList(DWD_SAT_WMS, DWD_SAT_WMS_FALLBACKS);
+
+  const url = endpoints[endpointIndex] ?? DEFAULT_WMS_ENDPOINTS[0];
+  layer = createLayer(L, url, opacity).addTo(map);
+
+  // Wenn ein lokaler Proxy oder der primäre DWD-Host ausfällt, automatisch auf
+  // den nächsten bekannten DWD-WMS-Endpunkt wechseln. Leaflet lädt WMS-Kacheln
+  // als <img>, daher ist hierfür kein CORS-Read nötig.
+  layer.once('tileerror', ()=>{
+    if(!layer) return;
+    if(endpointIndex >= endpoints.length - 1) return;
+    map.removeLayer(layer);
+    endpointIndex += 1;
+    addLayerWithFallback(L, map, opacity);
+  });
 }
 
 export function toggle(L, map, on, opacity=0.7){
   if(on){
     if(layer) map.removeLayer(layer);
-    usingFallbackHost = false;
-    layer = createLayer(L, resolvePrimaryWmsUrl(), opacity).addTo(map);
-
-    // Wenn der same-origin Proxy ausfällt (z.B. 5xx vom Upstream),
-    // wechsle automatisch auf den direkten DWD-Endpunkt.
-    // Leaflet lädt Kacheln als <img>, daher ist hierfür kein CORS-Read nötig.
-    // Damit bleibt das Satelliten-Layer auch bei Proxy-/Nginx-Störungen nutzbar.
-    layer.once('tileerror', ()=>{
-      if(!layer || usingFallbackHost) return;
-      map.removeLayer(layer);
-      usingFallbackHost = true;
-      layer = createLayer(L, DWD_SAT_WMS_FALLBACK, opacity).addTo(map);
-    });
+    endpointIndex = 0;
+    addLayerWithFallback(L, map, opacity);
   }else if(layer){
-    map.removeLayer(layer); layer=null;
-    usingFallbackHost = false;
+    map.removeLayer(layer);
+    layer = null;
+    endpointIndex = 0;
   }
 }
 
 export function setOpacity(val){ if(layer) layer.setOpacity(val); }
 
 export function syncTo(timeUnix){
-  // DWD WMS zeigt immer den aktuellsten Stand – kein Zeitsprung nötig.
-  // Cache-Bust um sicherzustellen, dass das neueste Bild geladen wird.
+  // Der WMS-Zeitpunkt wird serverseitig ausgewählt. Cache-Bust erzwingt bei
+  // Radar-Zeitsprüngen/Animationen eine frische Prüfung des neuesten DWD-Bildes.
   if(!layer) return;
   layer.setParams({ _t: Date.now() });
 }
+
+export const __test = { buildEndpointList, normalizeWmsUrl, DEFAULT_WMS_ENDPOINTS };

--- a/js/satellite.test.js
+++ b/js/satellite.test.js
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { DWD_SAT_LAYER, DWD_SAT_WMS, DWD_SAT_WMS_FALLBACKS } from './config.js';
+import { __test } from './satellite.js';
+
+const { buildEndpointList, normalizeWmsUrl } = __test;
+
+describe('DWD satellite WMS configuration', () => {
+  it('uses the current DWD Meteosat Europe RGB/IR layer', () => {
+    assert.equal(DWD_SAT_LAYER, 'dwd:Satellite_meteosat_1km_euat_rgb_day_hrv_and_night_ir108_3h');
+  });
+
+  it('keeps a local proxy first and direct DWD hosts as fallbacks', () => {
+    const endpoints = buildEndpointList(DWD_SAT_WMS, DWD_SAT_WMS_FALLBACKS);
+
+    assert.equal(endpoints[0], '/dwd/sat/wms?');
+    assert.ok(endpoints.includes('https://maps.dwd.de/geoserver/wms?'));
+    assert.ok(endpoints.includes('https://brz-maps.dwd.de/geoserver/wms?'));
+    assert.equal(new Set(endpoints).size, endpoints.length);
+  });
+
+  it('normalizes WMS URLs to include a query separator', () => {
+    assert.equal(normalizeWmsUrl('https://example.test/geoserver/wms'), 'https://example.test/geoserver/wms?');
+    assert.equal(normalizeWmsUrl(' https://example.test/geoserver/wms? '), 'https://example.test/geoserver/wms?');
+    assert.equal(normalizeWmsUrl(''), null);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "node --test js/windflow.test.js",
+    "test": "node --test js/*.test.js",
     "wind:once": "node wind-fetcher.js --once",
     "wind:watch": "node wind-fetcher.js"
   },

--- a/wetter_nginx.conf
+++ b/wetter_nginx.conf
@@ -40,7 +40,7 @@ server {
         # Direkter WMS-Endpunkt statt /ows, um Upstream-Gateway-Probleme zu vermeiden.
         # Kein Variablenanteil im Upstream-Host, damit kein separater `resolver`
         # erforderlich ist (sonst: "no resolver defined to resolve maps.dwd.de").
-        proxy_pass https://maps.dwd.de/geoserver/dwd/wms?$args;
+        proxy_pass https://maps.dwd.de/geoserver/wms?$args;
         proxy_set_header Host maps.dwd.de;
         proxy_ssl_server_name on;
         proxy_ssl_name maps.dwd.de;


### PR DESCRIPTION
### Motivation
- Re-enable the DWD satellite overlay using the current Meteosat Europe product served by the DWD GeoServer and ensure correct EUMETSAT/DWD attribution (CC BY 4.0). 
- Make the frontend resilient to proxy/upstream failures by preferring a same-origin proxy and falling back to direct DWD hosts. 
- Clarify in docs that opendata.dwd.de contains complementary raw products (NetCDF/etc.) while the WMS is used for browser tiles. 

### Description
- Rewrote `js/satellite.js` to build a normalized, deduplicated list of WMS endpoints, try a local proxy first (`/dwd/sat/wms?`) and automatically rotate through fallback endpoints on tile errors. 
- Updated `js/config.js` to point `DWD_SAT_WMS` at the local proxy, added `DWD_SAT_WMS_FALLBACKS`, and set `DWD_SAT_LAYER` to `dwd:Satellite_meteosat_1km_euat_rgb_day_hrv_and_night_ir108_3h`. 
- Updated UI copy and footer in `index.html` and README to reference `EUMETSAT / DWD (CC BY 4.0)` and documented the OpenData/raw-product context and fallback behavior. 
- Adjusted example Nginx proxy configs (`wetter_nginx.conf` and `etc/nginx/sites-available/wetter.domain.tld`) to use the current GeoServer WMS path and return a valid empty tile on upstream errors. 
- Added `js/satellite.test.js` and broadened the test script in `package.json` to run all `js/*.test.js` tests. 

### Testing
- Ran `npm test` (now `node --test js/*.test.js`), which executed 5 tests across the new DWD satellite config tests and existing windflow tests and all passed. 
- Performed an environment check for `playwright`, which is not available in this environment so browser screenshot capture could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29c4d8e7cc8327b81efc865321d38e)