### PR TITLE
Satelliten-Overlay zeitfähig machen und Regen/Schnee-Switch entfernen

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -65,11 +65,6 @@ body.dark .panel-toggle{background:rgba(255,255,255,0.12);}
 .hint{font-size:12px;color:var(--fg-hint)}
 .badge{display:inline-block;padding:2px 6px;border-radius:6px;font-size:12px;background:#eef;color:#223}
 body.dark .badge{background:rgba(33,150,243,0.35);color:#e3f2fd;}
-.precip-legend{display:flex;align-items:center;gap:6px;flex-wrap:wrap}
-.legend-chip{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:999px;font-weight:700;font-size:12px;color:#fff;box-shadow:0 1px 4px rgba(0,0,0,0.18);}
-.legend-chip--rain{background:linear-gradient(135deg,#1e88e5,#0d47a1);}
-.legend-chip--snow{background:linear-gradient(135deg,#90caf9,#e3f2fd);color:#0b3954;border:1px solid rgba(0,0,0,0.08);}
-body.dark .legend-chip--snow{color:#0e1d2f;border-color:rgba(255,255,255,0.18);box-shadow:0 1px 4px rgba(0,0,0,0.35);}
 
 /* Legende oben rechts */
 .legend{

--- a/index.html
+++ b/index.html
@@ -58,16 +58,6 @@
         <span id="lblOpacity">85%</span>
       </div>
       <div class="row">
-        <label for="chkPrecipType">Niederschlagstyp</label>
-        <input type="checkbox" id="chkPrecipType">
-        <span class="hint">Regen vs. Schnee</span>
-        <div class="precip-legend" id="precipLegend" aria-label="Legende Niederschlagstyp">
-          <span class="legend-chip legend-chip--rain">Regen</span>
-          <span class="legend-chip legend-chip--snow">Schnee</span>
-        </div>
-        <span id="lblPrecipStatus" class="badge" style="display:none"></span>
-      </div>
-      <div class="row">
         <label for="chkClouds">Satellit (DWD/EUMETSAT)</label>
         <input type="checkbox" id="chkClouds">
         <input id="rngClouds" type="range" min="0.2" max="1" step="0.05" value="0.7" class="grow">

--- a/js/app.js
+++ b/js/app.js
@@ -34,7 +34,6 @@ const ui = {
   lblTime:$('lblTime'), btnLocate:$('btnLocate'), lblLocationWind:$('lblLocationWind'),
   selColor:$('selColor'), chkSmooth:$('chkSmooth'), rngSpeed:$('rngSpeed'),
   rngOpacity:$('rngOpacity'), lblOpacity:$('lblOpacity'),
-  chkPrecipType:$('chkPrecipType'), lblPrecipStatus:$('lblPrecipStatus'),
   chkClouds:$('chkClouds'), rngClouds:$('rngClouds'), lblClouds:$('lblClouds'),
   chkWarn:$('chkWarn'), chkWarnList:$('chkWarnList'),
   chkDark:$('chkDark'),
@@ -59,16 +58,6 @@ if(ui.btnPanelToggle && ui.controlPanel){
 
 function syncClouds(timeUnix){ Sat.syncTo(timeUnix); }
 
-function updatePrecipStatus(){
-  if(!ui.lblPrecipStatus) return;
-  if(ui.chkPrecipType?.checked){
-    ui.lblPrecipStatus.textContent = 'PrecipType: ON';
-    ui.lblPrecipStatus.style.display = 'inline-block';
-  }else{
-    ui.lblPrecipStatus.style.display = 'none';
-  }
-}
-
 async function boot(){
   await Radar.loadRadar();
   await Sat.loadSatellite();
@@ -90,7 +79,6 @@ async function boot(){
   ui.rngOpacity.oninput = ()=>{
     ui.lblOpacity.textContent = Math.round(Number(ui.rngOpacity.value)*100)+'%';
   };
-  ui.chkPrecipType.onchange = ()=>{ updatePrecipStatus(); Radar.paint(L,map,ui,syncClouds); };
   ui.selColor.onchange = ()=> Radar.paint(L,map,ui,syncClouds);
   ui.chkSmooth.onchange = ()=> Radar.paint(L,map,ui,syncClouds);
 
@@ -99,7 +87,6 @@ async function boot(){
 
   ui.chkDark.onchange = ()=> applyDarkMode(ui.chkDark.checked);
   applyDarkMode(ui.chkDark.checked);
-  updatePrecipStatus();
 
   const locationTooltipOptions = { permanent:true, direction:'top', offset:[0,-22], className:'wind-tooltip' };
   let locateMarker=null, locateCircle=null;

--- a/js/radar.js
+++ b/js/radar.js
@@ -47,7 +47,7 @@ function radarUrl(frame, ui){
   // RainViewer Free-Tier: nur noch Farbschema 8 (Universal Blue) verfügbar
   const color = 8;
   const smooth = ui.chkSmooth.checked ? 1 : 0;
-  const snow = ui?.chkPrecipType?.checked ? 1 : 0;
+  const snow = 0;
   const host=(RV_HOST||RV_HOST_FALLBACK).replace(/\/+$/,'');
   let path=String(frame.path||'').replace(/^\/+/,'');
   if (!path.startsWith('v2/')) path = 'v2/radar/' + path;

--- a/js/satellite.js
+++ b/js/satellite.js
@@ -1,8 +1,7 @@
 // Satellitenbilder via DWD-WMS.
-// Das Meteosat-Europabild wird bewusst als einzelnes WMS-GetMap-Bild geladen:
-// Der DWD-Beispiellink für dieses Produkt nutzt eine feste EPSG:4326-Europe-
-// Bounding-Box. Leaflet-WMS-Kacheln in WebMercator können für dieses Produkt je
-// nach Server/Proxy leer bleiben; ein ImageOverlay zeigt die DWD-Ausgabe stabil.
+// Das Meteosat-Europabild wird als WMS-GetMap-Bild geladen. Für die Animation
+// nutzt der DWD/GeoServer die standardisierte WMS-Zeitdimension: GetCapabilities
+// liefert verfügbare Zeitpunkte/Intervalle, GetMap akzeptiert diese über TIME=.
 import { DWD_SAT_BOUNDS, DWD_SAT_IMAGE, DWD_SAT_LAYER, DWD_SAT_WMS, DWD_SAT_WMS_FALLBACKS } from './config.js';
 
 const DEFAULT_WMS_ENDPOINTS = [
@@ -11,18 +10,38 @@ const DEFAULT_WMS_ENDPOINTS = [
   'https://brz-maps.dwd.de/geoserver/wms?',
 ];
 
+const SATELLITE_FRAME_INTERVAL_MS = 60 * 60 * 1000;
+const FALLBACK_FRAME_COUNT = 24;
+
 let layer = null;
 let endpointIndex = 0;
 let endpoints = [];
+let frames = [];
+let currentFrameIndex = 0;
 let currentOpacity = 0.7;
 let currentL = null;
 let currentMap = null;
 
 export async function loadSatellite(){
-  // DWD WMS benötigt kein Vorab-Laden von Frames – der Layer zeigt immer den
-  // neuesten vom DWD veröffentlichten Zeitschritt des Satellitenprodukts.
   endpoints = buildEndpointList(DWD_SAT_WMS, DWD_SAT_WMS_FALLBACKS);
-  return [];
+  frames = [];
+
+  for (const endpoint of endpoints) {
+    try {
+      const discovered = await fetchSatelliteFrames(endpoint);
+      if (discovered.length) {
+        frames = discovered;
+        currentFrameIndex = frames.length - 1;
+        return frames;
+      }
+    } catch (err) {
+      console.warn('DWD-Satellitenzeiten konnten nicht geladen werden:', endpoint, err);
+    }
+  }
+
+  frames = buildFallbackHourlyFrames();
+  currentFrameIndex = frames.length - 1;
+  return frames;
 }
 
 function normalizeWmsUrl(url){
@@ -45,7 +64,7 @@ function getImageConfig(){
   return { bounds, width: image.width ?? 1024, height: image.height ?? 574 };
 }
 
-function buildGetMapUrl(endpoint, cacheBust = Date.now()){
+function buildGetMapUrl(endpoint, cacheBust = Date.now(), timeIso = getCurrentFrame()?.iso){
   const { bounds, width, height } = getImageConfig();
   const [[south, west], [north, east]] = bounds;
   const params = new URLSearchParams({
@@ -62,7 +81,95 @@ function buildGetMapUrl(endpoint, cacheBust = Date.now()){
     height: String(height),
     _t: String(cacheBust),
   });
+  if (timeIso) params.set('time', timeIso);
   return `${normalizeWmsUrl(endpoint)}${params.toString()}`;
+}
+
+function buildGetCapabilitiesUrl(endpoint){
+  const params = new URLSearchParams({ service: 'WMS', version: '1.1.1', request: 'GetCapabilities' });
+  return `${normalizeWmsUrl(endpoint)}${params.toString()}`;
+}
+
+async function fetchSatelliteFrames(endpoint){
+  const res = await fetch(buildGetCapabilitiesUrl(endpoint), { cache: 'no-store' });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const xml = await res.text();
+  return parseSatelliteTimes(xml).map(iso => ({ time: Date.parse(iso) / 1000, iso }));
+}
+
+function parseSatelliteTimes(xml){
+  const layerPattern = /<Layer\b[\s\S]*?<Name>\s*dwd:Satellite_meteosat_1km_euat_rgb_day_hrv_and_night_ir108_3h\s*<\/Name>[\s\S]*?<\/Layer>/i;
+  const layerXml = xml.match(layerPattern)?.[0] || '';
+  if (!layerXml) return [];
+
+  const times = [...layerXml.matchAll(/<(?:Extent|Dimension)\b[^>]*name=["']time["'][^>]*>([\s\S]*?)<\/(?:Extent|Dimension)>/gi)]
+    .flatMap(match => expandTimeList(decodeXmlEntities(match[1])));
+  return [...new Set(times)].filter(iso => Number.isFinite(Date.parse(iso))).sort((a, b) => Date.parse(a) - Date.parse(b));
+}
+
+function decodeXmlEntities(value){
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function expandTimeList(value){
+  return value.split(',').map(part => part.trim()).filter(Boolean).flatMap(part => {
+    const pieces = part.split('/').map(piece => piece.trim());
+    if (pieces.length !== 3) return [normalizeIsoTime(part)].filter(Boolean);
+    return expandTimeInterval(pieces[0], pieces[1], pieces[2]);
+  });
+}
+
+function expandTimeInterval(startRaw, endRaw, periodRaw){
+  const start = Date.parse(startRaw);
+  const end = Date.parse(endRaw);
+  const step = parseIsoPeriodMs(periodRaw);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || !step) return [];
+  const values = [];
+  for (let t = start; t <= end && values.length < 240; t += step) values.push(new Date(t).toISOString());
+  return values;
+}
+
+function parseIsoPeriodMs(period){
+  const match = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/i.exec(period.trim());
+  if (!match) return 0;
+  const days = Number(match[1] || 0);
+  const hours = Number(match[2] || 0);
+  const minutes = Number(match[3] || 0);
+  const seconds = Number(match[4] || 0);
+  return (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
+}
+
+function normalizeIsoTime(value){
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
+}
+
+function buildFallbackHourlyFrames(now = Date.now()){
+  const end = Math.floor(now / SATELLITE_FRAME_INTERVAL_MS) * SATELLITE_FRAME_INTERVAL_MS;
+  return Array.from({ length: FALLBACK_FRAME_COUNT }, (_, i) => {
+    const timeMs = end - (FALLBACK_FRAME_COUNT - 1 - i) * SATELLITE_FRAME_INTERVAL_MS;
+    return { time: timeMs / 1000, iso: new Date(timeMs).toISOString() };
+  });
+}
+
+function getCurrentFrame(){
+  return frames[currentFrameIndex] ?? null;
+}
+
+function findNearestFrameIndex(timeUnix){
+  if (!frames.length || !Number.isFinite(timeUnix)) return currentFrameIndex;
+  let nearest = 0;
+  let nearestDistance = Infinity;
+  frames.forEach((frame, i) => {
+    const distance = Math.abs(frame.time - timeUnix);
+    if (distance < nearestDistance) { nearest = i; nearestDistance = distance; }
+  });
+  return nearest;
 }
 
 function createLayer(L, url, opacity){
@@ -81,9 +188,6 @@ function addLayerWithFallback(L, map, opacity){
   const endpoint = endpoints[endpointIndex] ?? DEFAULT_WMS_ENDPOINTS[0];
   layer = createLayer(L, buildGetMapUrl(endpoint), opacity).addTo(map);
 
-  // Bei echten Ladefehlern den nächsten bekannten DWD-Endpunkt versuchen. Ein
-  // lokaler Proxy ist absichtlich nur Fallback, weil manche Proxy-Configs bei
-  // Upstream-Fehlern ein valides, aber leeres 1x1-Bild mit HTTP 200 liefern.
   layer.once('error', ()=>{
     if(!layer) return;
     if(endpointIndex >= endpoints.length - 1) return;
@@ -114,12 +218,23 @@ export function setOpacity(val){
 }
 
 export function syncTo(timeUnix){
-  // Der WMS-Zeitpunkt wird serverseitig ausgewählt. Cache-Bust erzwingt bei
-  // Radar-Zeitsprüngen/Animationen eine frische Prüfung des neuesten DWD-Bildes.
   if(!layer) return;
+  currentFrameIndex = findNearestFrameIndex(timeUnix);
   const endpoint = endpoints[endpointIndex] ?? DEFAULT_WMS_ENDPOINTS[0];
   if(typeof layer.setUrl === 'function') layer.setUrl(buildGetMapUrl(endpoint));
   else if(currentL && currentMap) toggle(currentL, currentMap, true, currentOpacity);
 }
 
-export const __test = { buildEndpointList, buildGetMapUrl, getImageConfig, normalizeWmsUrl, DEFAULT_WMS_ENDPOINTS };
+export const __test = {
+  DEFAULT_WMS_ENDPOINTS,
+  SATELLITE_FRAME_INTERVAL_MS,
+  buildEndpointList,
+  buildFallbackHourlyFrames,
+  buildGetCapabilitiesUrl,
+  buildGetMapUrl,
+  expandTimeList,
+  getImageConfig,
+  normalizeWmsUrl,
+  parseIsoPeriodMs,
+  parseSatelliteTimes,
+};

--- a/js/satellite.test.js
+++ b/js/satellite.test.js
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test';
 import { DWD_SAT_BOUNDS, DWD_SAT_IMAGE, DWD_SAT_LAYER, DWD_SAT_WMS, DWD_SAT_WMS_FALLBACKS } from './config.js';
 import { __test } from './satellite.js';
 
-const { buildEndpointList, buildGetMapUrl, getImageConfig, normalizeWmsUrl } = __test;
+const { buildEndpointList, buildFallbackHourlyFrames, buildGetCapabilitiesUrl, buildGetMapUrl, expandTimeList, getImageConfig, normalizeWmsUrl, parseIsoPeriodMs, parseSatelliteTimes } = __test;
 
 describe('DWD satellite WMS configuration', () => {
   it('uses the current DWD Meteosat Europe RGB/IR layer', () => {
@@ -26,8 +26,8 @@ describe('DWD satellite WMS configuration', () => {
     assert.equal(normalizeWmsUrl(''), null);
   });
 
-  it('builds a fixed EPSG:4326 GetMap URL for the Europe image overlay', () => {
-    const url = buildGetMapUrl(DWD_SAT_WMS, 12345);
+  it('builds a fixed EPSG:4326 GetMap URL for a timed Europe image overlay', () => {
+    const url = buildGetMapUrl(DWD_SAT_WMS, 12345, '2026-07-10T09:00:00.000Z');
     const parsed = new URL(url);
 
     assert.equal(parsed.origin + parsed.pathname + '?', DWD_SAT_WMS);
@@ -40,6 +40,46 @@ describe('DWD satellite WMS configuration', () => {
     assert.equal(parsed.searchParams.get('width'), String(DWD_SAT_IMAGE.width));
     assert.equal(parsed.searchParams.get('height'), String(DWD_SAT_IMAGE.height));
     assert.equal(parsed.searchParams.get('_t'), '12345');
+    assert.equal(parsed.searchParams.get('time'), '2026-07-10T09:00:00.000Z');
+  });
+
+  it('builds a GetCapabilities URL for WMS time discovery', () => {
+    const parsed = new URL(buildGetCapabilitiesUrl(DWD_SAT_WMS));
+
+    assert.equal(parsed.origin + parsed.pathname + '?', DWD_SAT_WMS);
+    assert.equal(parsed.searchParams.get('service'), 'WMS');
+    assert.equal(parsed.searchParams.get('version'), '1.1.1');
+    assert.equal(parsed.searchParams.get('request'), 'GetCapabilities');
+  });
+
+  it('expands WMS time lists and ISO-8601 intervals', () => {
+    assert.equal(parseIsoPeriodMs('PT1H'), 60 * 60 * 1000);
+    assert.deepEqual(expandTimeList('2026-07-10T00:00:00Z/2026-07-10T02:00:00Z/PT1H'), [
+      '2026-07-10T00:00:00.000Z',
+      '2026-07-10T01:00:00.000Z',
+      '2026-07-10T02:00:00.000Z',
+    ]);
+  });
+
+  it('parses satellite layer time dimensions from WMS capabilities XML', () => {
+    const xml = `<WMT_MS_Capabilities><Capability><Layer><Layer>
+      <Name>${DWD_SAT_LAYER}</Name>
+      <Extent name="time">2026-07-10T00:00:00Z/2026-07-10T02:00:00Z/PT1H</Extent>
+    </Layer></Layer></Capability></WMT_MS_Capabilities>`;
+
+    assert.deepEqual(parseSatelliteTimes(xml), [
+      '2026-07-10T00:00:00.000Z',
+      '2026-07-10T01:00:00.000Z',
+      '2026-07-10T02:00:00.000Z',
+    ]);
+  });
+
+  it('creates hourly fallback frames when WMS capabilities are unavailable', () => {
+    const frames = buildFallbackHourlyFrames(Date.parse('2026-07-10T02:34:00Z'));
+
+    assert.equal(frames.length, 24);
+    assert.equal(frames.at(-1).iso, '2026-07-10T02:00:00.000Z');
+    assert.equal(frames.at(-2).iso, '2026-07-10T01:00:00.000Z');
   });
 
   it('keeps the image overlay bounds in south-west/north-east Leaflet order', () => {


### PR DESCRIPTION
### Motivation
- Das Satellitenbild soll als zeitschrittbare Animation im stündlichen Intervall abgespielt werden und mit den Radar-Frames synchronisierbar sein. 
- Verfügbare WMS-Zeitdimensionen vom DWD sollen genutzt werden, mit stündlichen Fallback-Frames, falls Capabilities nicht lesbar sind. 
- Der UI-Schalter für Regen/Schnee wurde entfernt, da die RainViewer-Free-Tier-Optionen eingeschränkt sind und der Umschalt-Flow nicht mehr benötigt wird.

### Description
- Implementiert WMS-Zeit-Discovery: `GetCapabilities` wird ausgewertet, Zeit-`Extent`/`Dimension`-Werte geparst und in GetMap-Requests als `time`-Parameter übergeben (Hauptänderung in `js/satellite.js`).
- Fallback-Mechanismus erzeugt stündliche Frames (`SATELLITE_FRAME_INTERVAL_MS`, `buildFallbackHourlyFrames`) falls Capabilities nicht erreichbar sind, und die Satellitenebene wählt beim Sync den nächstliegenden Frame (`findNearestFrameIndex`, `syncTo`).
- UI- und Logikbereinigung: Entfernt den Niederschlagstyp-Schalter aus `index.html` und `js/app.js` sowie die zugehörige Legenden-CSS in `css/app.css`; Radar-URL-Build zwingt nun den Standard-Precip-Modus (`snow = 0`) in `js/radar.js`.
- Tests erweitert/neu: `js/satellite.test.js` ergänzt um GetCapabilities-URL, timed `GetMap`-URL, ISO-8601-Intervallexpansion und Fallback-Frames; `__test`-Export in `js/satellite.js` angepasst.

### Testing
- `npm test` wurde ausgeführt und alle Tests liefen erfolgreich (`11 passed`, `0 failed`).
- Syntax/parsability geprüft mit `node --check js/app.js`, `node --check js/radar.js`, `node --check js/satellite.js` und alle Dateien sind syntaktisch korrekt.
- Grep/Checks zur Entfernung des Precip-Type-UI und der Legende erfolgten mit `rg` und lieferten keine verbleibenden UI-Elemente/Styles für Regen/Schnee mehr.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5172a9d3d88327900b1f5633ab6a91)