### PR TITLE
PEGELONLINE-Pegelstände als zuschaltbare Kartenebene

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,117 +5,28 @@
   <title>Wetterradar – Radar, Wolken, Wind, Warnungen</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/css/app.css">
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-        integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin>
-  <style>
-    .current-time-marker {
-      position: absolute;
-      top: 10px;
-      left: 50%;
-      transform: translateX(-50%);
-      background: rgba(255, 0, 0, 0.7);
-      color: white;
-      padding: 2px 8px;
-      border-radius: 4px;
-      font-size: 0.8em;
-      z-index: 1000;
-      pointer-events: none;
-    }
-  </style>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin>
 </head>
 <body>
   <div id="map" role="region" aria-label="Wetterradar"></div>
-  <div id="currentTimeMarker" class="current-time-marker" style="display: none;">⏰ Jetzt</div>
-
-  <!-- Panel unten links -->
+  <div id="currentTimeMarker" class="current-time-marker" style="display:none;">⏰ Jetzt</div>
   <div class="panel" id="controlPanel">
-    <div class="panel-header">
-      <strong>Steuerung</strong>
-      <button id="btnPanelToggle" class="panel-toggle" aria-expanded="true" aria-label="Bedienpanel einklappen">▾</button>
-    </div>
+    <div class="panel-header"><strong>Steuerung</strong><button id="btnPanelToggle" class="panel-toggle" aria-expanded="true" aria-label="Bedienpanel einklappen">▾</button></div>
     <div class="panel-body" id="panelBody">
-      <div class="row">
-        <button id="btnPrev">⟵</button>
-        <button id="btnPlay">▶︎</button>
-        <button id="btnNext">⟶</button>
-        <div class="grow" id="lblTime">Lade…</div>
-        <button id="btnLocate">📍</button>
-        <span id="lblLocationWind" class="badge" style="display:none"></span>
-      </div>
-      <div class="row">
-        <label for="selColor">Farbschema</label>
-        <select id="selColor" disabled>
-          <option value="8" selected>Universal Blue</option>
-        </select>
-        <label for="chkSmooth">Smooth</label>
-        <input type="checkbox" id="chkSmooth" checked>
-        <label for="rngSpeed">⏩</label>
-        <input id="rngSpeed" type="range" min="200" max="1200" step="100" value="700" class="grow">
-      </div>
-      <div class="row">
-        <label for="rngOpacity">Deckkraft Radar</label>
-        <input id="rngOpacity" type="range" min="0.2" max="1" step="0.05" value="0.85" class="grow">
-        <span id="lblOpacity">85%</span>
-      </div>
-      <div class="row">
-        <label for="chkClouds">Satellit (DWD/EUMETSAT)</label>
-        <input type="checkbox" id="chkClouds">
-        <input id="rngClouds" type="range" min="0.2" max="1" step="0.05" value="0.7" class="grow">
-        <span id="lblClouds">70%</span>
-      </div>
-      <div class="row">
-        <label for="chkWindFlow">Windströmung</label>
-        <input type="checkbox" id="chkWindFlow">
-        <label for="selWindRegion">Region</label>
-        <select id="selWindRegion">
-          <option value="germany" selected>Deutschland</option>
-          <option value="europe">Europa</option>
-          <option value="world">Welt</option>
-        </select>
-        <span id="lblWindFlowInfo" class="hint">animiertes Feld (experimentell)</span>
-      </div>
-      <div class="row">
-        <label for="chkWarn">Wetterwarnungen (DWD)</label>
-        <input type="checkbox" id="chkWarn">
-        <label for="chkNina">Warnungen (BBK/NINA)</label>
-        <input type="checkbox" id="chkNina">
-        <label for="chkWarnList">Warnliste</label>
-        <input type="checkbox" id="chkWarnList">
-      </div>
-
-      <div class="row">
-        <label for="chkDark">Dark-Mode</label>
-        <input type="checkbox" id="chkDark">
-      </div>
+      <div class="row"><button id="btnPrev">⟵</button><button id="btnPlay">▶︎</button><button id="btnNext">⟶</button><div class="grow" id="lblTime">Lade…</div><button id="btnLocate">📍</button><span id="lblLocationWind" class="badge" style="display:none"></span></div>
+      <div class="row"><label for="selColor">Farbschema</label><select id="selColor" disabled><option value="8" selected>Universal Blue</option></select><label for="chkSmooth">Smooth</label><input type="checkbox" id="chkSmooth" checked><label for="rngSpeed">⏩</label><input id="rngSpeed" type="range" min="200" max="1200" step="100" value="700" class="grow"></div>
+      <div class="row"><label for="rngOpacity">Deckkraft Radar</label><input id="rngOpacity" type="range" min="0.2" max="1" step="0.05" value="0.85" class="grow"><span id="lblOpacity">85%</span></div>
+      <div class="row"><label for="chkClouds">Satellit (DWD/EUMETSAT)</label><input type="checkbox" id="chkClouds"><input id="rngClouds" type="range" min="0.2" max="1" step="0.05" value="0.7" class="grow"><span id="lblClouds">70%</span></div>
+      <div class="row"><label for="chkWindFlow">Windströmung</label><input type="checkbox" id="chkWindFlow"><label for="selWindRegion">Region</label><select id="selWindRegion"><option value="germany" selected>Deutschland</option><option value="europe">Europa</option><option value="world">Welt</option></select><span id="lblWindFlowInfo" class="hint">animiertes Feld (experimentell)</span></div>
+      <div class="row"><label for="chkWaterLevels">Pegelstände (WSV)</label><input type="checkbox" id="chkWaterLevels"><span id="lblWaterLevelsInfo" class="hint">aus</span></div>
+      <div class="row"><label for="chkWarn">Wetterwarnungen (DWD)</label><input type="checkbox" id="chkWarn"><label for="chkNina">Warnungen (BBK/NINA)</label><input type="checkbox" id="chkNina"><label for="chkWarnList">Warnliste</label><input type="checkbox" id="chkWarnList"></div>
+      <div class="row"><label for="chkDark">Dark-Mode</label><input type="checkbox" id="chkDark"></div>
     </div>
   </div>
-
-  <!-- Legende / Counter / Warnliste rechts oben -->
-  <div id="legend" class="legend">
-    <div>Niederschlag (mm/h)</div>
-    <div class="scale"></div>
-    <div class="ticks"><span>Leicht</span><span>Mittel</span><span>Stark</span></div>
-  </div>
-
-  <div id="warnList" class="warnlist" style="display:none;">
-    <div class="warnlist-tabs" role="tablist" aria-label="Warnquellen">
-      <button id="tabDwd" class="tab active" role="tab" aria-selected="true" aria-controls="panelDwd">DWD</button>
-      <button id="tabNina" class="tab" role="tab" aria-selected="false" aria-controls="panelNina">BBK / NINA</button>
-    </div>
-    <div id="panelDwd" class="warnlist-panel" role="tabpanel" aria-labelledby="tabDwd">
-      <div class="title">Aktuelle Wetterwarnungen (DWD)</div>
-      <div id="warnItemsDwd"></div>
-    </div>
-    <div id="panelNina" class="warnlist-panel" role="tabpanel" aria-labelledby="tabNina" hidden>
-      <div class="title">Warnungen (BBK / NINA)</div>
-      <div id="warnItemsNina"></div>
-    </div>
-  </div>
-
-  <footer class="footer">Radar: RainViewer • Satellit: EUMETSAT / DWD (CC BY 4.0) • Wind: Open-Meteo • OSM © Mitwirkende</footer>
-
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-          integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin></script>
+  <div id="legend" class="legend"><div>Niederschlag (mm/h)</div><div class="scale"></div><div class="ticks"><span>Leicht</span><span>Mittel</span><span>Stark</span></div></div>
+  <div id="warnList" class="warnlist" style="display:none;"><div class="warnlist-tabs" role="tablist" aria-label="Warnquellen"><button id="tabDwd" class="tab active" role="tab" aria-selected="true" aria-controls="panelDwd">DWD</button><button id="tabNina" class="tab" role="tab" aria-selected="false" aria-controls="panelNina">BBK / NINA</button></div><div id="panelDwd" class="warnlist-panel" role="tabpanel" aria-labelledby="tabDwd"><div class="title">Aktuelle Wetterwarnungen (DWD)</div><div id="warnItemsDwd"></div></div><div id="panelNina" class="warnlist-panel" role="tabpanel" aria-labelledby="tabNina" hidden><div class="title">Warnungen (BBK / NINA)</div><div id="warnItemsNina"></div></div></div>
+  <footer class="footer">Radar: RainViewer • Satellit: EUMETSAT / DWD (CC BY 4.0) • Wind: Open-Meteo • Pegel: PEGELONLINE / WSV • OSM © Mitwirkende</footer>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin></script>
   <script src="https://unpkg.com/leaflet-velocity/dist/leaflet-velocity.min.js"></script>
   <script type="module" src="/js/app.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -6,28 +6,28 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="/css/app.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin>
+  <style>
+    .current-time-marker{position:absolute;top:10px;left:50%;transform:translateX(-50%);background:rgba(255,0,0,.7);color:#fff;padding:2px 8px;border-radius:4px;font-size:.8em;z-index:1000;pointer-events:none}
+    .pegel-marker{background:transparent;border:0}
+    .pegel-marker__inner{min-width:42px;height:28px;padding:2px 5px;box-sizing:border-box;border:2px solid #fff;border-radius:8px;background:var(--pegel-color);color:#fff;font:700 13px/20px system-ui;text-align:center;box-shadow:0 2px 7px rgba(0,0,0,.35);white-space:nowrap}
+    .pegel-marker__inner span{font-size:9px;margin-left:2px;font-weight:600}
+    .pegel-popup{font:13px/1.45 system-ui}
+  </style>
 </head>
 <body>
-  <div id="map" role="region" aria-label="Wetterradar"></div>
-  <div id="currentTimeMarker" class="current-time-marker" style="display:none;">⏰ Jetzt</div>
-  <div class="panel" id="controlPanel">
-    <div class="panel-header"><strong>Steuerung</strong><button id="btnPanelToggle" class="panel-toggle" aria-expanded="true" aria-label="Bedienpanel einklappen">▾</button></div>
-    <div class="panel-body" id="panelBody">
-      <div class="row"><button id="btnPrev">⟵</button><button id="btnPlay">▶︎</button><button id="btnNext">⟶</button><div class="grow" id="lblTime">Lade…</div><button id="btnLocate">📍</button><span id="lblLocationWind" class="badge" style="display:none"></span></div>
-      <div class="row"><label for="selColor">Farbschema</label><select id="selColor" disabled><option value="8" selected>Universal Blue</option></select><label for="chkSmooth">Smooth</label><input type="checkbox" id="chkSmooth" checked><label for="rngSpeed">⏩</label><input id="rngSpeed" type="range" min="200" max="1200" step="100" value="700" class="grow"></div>
-      <div class="row"><label for="rngOpacity">Deckkraft Radar</label><input id="rngOpacity" type="range" min="0.2" max="1" step="0.05" value="0.85" class="grow"><span id="lblOpacity">85%</span></div>
-      <div class="row"><label for="chkClouds">Satellit (DWD/EUMETSAT)</label><input type="checkbox" id="chkClouds"><input id="rngClouds" type="range" min="0.2" max="1" step="0.05" value="0.7" class="grow"><span id="lblClouds">70%</span></div>
-      <div class="row"><label for="chkWindFlow">Windströmung</label><input type="checkbox" id="chkWindFlow"><label for="selWindRegion">Region</label><select id="selWindRegion"><option value="germany" selected>Deutschland</option><option value="europe">Europa</option><option value="world">Welt</option></select><span id="lblWindFlowInfo" class="hint">animiertes Feld (experimentell)</span></div>
-      <div class="row"><label for="chkWaterLevels">Pegelstände (WSV)</label><input type="checkbox" id="chkWaterLevels"><span id="lblWaterLevelsInfo" class="hint">aus</span></div>
-      <div class="row"><label for="chkWarn">Wetterwarnungen (DWD)</label><input type="checkbox" id="chkWarn"><label for="chkNina">Warnungen (BBK/NINA)</label><input type="checkbox" id="chkNina"><label for="chkWarnList">Warnliste</label><input type="checkbox" id="chkWarnList"></div>
-      <div class="row"><label for="chkDark">Dark-Mode</label><input type="checkbox" id="chkDark"></div>
-    </div>
-  </div>
+  <div id="map" role="region" aria-label="Wetterradar"></div><div id="currentTimeMarker" class="current-time-marker" style="display:none;">⏰ Jetzt</div>
+  <div class="panel" id="controlPanel"><div class="panel-header"><strong>Steuerung</strong><button id="btnPanelToggle" class="panel-toggle" aria-expanded="true" aria-label="Bedienpanel einklappen">▾</button></div><div class="panel-body" id="panelBody">
+    <div class="row"><button id="btnPrev">⟵</button><button id="btnPlay">▶︎</button><button id="btnNext">⟶</button><div class="grow" id="lblTime">Lade…</div><button id="btnLocate">📍</button><span id="lblLocationWind" class="badge" style="display:none"></span></div>
+    <div class="row"><label for="selColor">Farbschema</label><select id="selColor" disabled><option value="8" selected>Universal Blue</option></select><label for="chkSmooth">Smooth</label><input type="checkbox" id="chkSmooth" checked><label for="rngSpeed">⏩</label><input id="rngSpeed" type="range" min="200" max="1200" step="100" value="700" class="grow"></div>
+    <div class="row"><label for="rngOpacity">Deckkraft Radar</label><input id="rngOpacity" type="range" min="0.2" max="1" step="0.05" value="0.85" class="grow"><span id="lblOpacity">85%</span></div>
+    <div class="row"><label for="chkClouds">Satellit (DWD/EUMETSAT)</label><input type="checkbox" id="chkClouds"><input id="rngClouds" type="range" min="0.2" max="1" step="0.05" value="0.7" class="grow"><span id="lblClouds">70%</span></div>
+    <div class="row"><label for="chkWindFlow">Windströmung</label><input type="checkbox" id="chkWindFlow"><label for="selWindRegion">Region</label><select id="selWindRegion"><option value="germany" selected>Deutschland</option><option value="europe">Europa</option><option value="world">Welt</option></select><span id="lblWindFlowInfo" class="hint">animiertes Feld (experimentell)</span></div>
+    <div class="row"><label for="chkWaterLevels">Pegelstände (WSV)</label><input type="checkbox" id="chkWaterLevels"><span id="lblWaterLevelsInfo" class="hint">aus</span></div>
+    <div class="row"><label for="chkWarn">Wetterwarnungen (DWD)</label><input type="checkbox" id="chkWarn"><label for="chkNina">Warnungen (BBK/NINA)</label><input type="checkbox" id="chkNina"><label for="chkWarnList">Warnliste</label><input type="checkbox" id="chkWarnList"></div>
+    <div class="row"><label for="chkDark">Dark-Mode</label><input type="checkbox" id="chkDark"></div>
+  </div></div>
   <div id="legend" class="legend"><div>Niederschlag (mm/h)</div><div class="scale"></div><div class="ticks"><span>Leicht</span><span>Mittel</span><span>Stark</span></div></div>
   <div id="warnList" class="warnlist" style="display:none;"><div class="warnlist-tabs" role="tablist" aria-label="Warnquellen"><button id="tabDwd" class="tab active" role="tab" aria-selected="true" aria-controls="panelDwd">DWD</button><button id="tabNina" class="tab" role="tab" aria-selected="false" aria-controls="panelNina">BBK / NINA</button></div><div id="panelDwd" class="warnlist-panel" role="tabpanel" aria-labelledby="tabDwd"><div class="title">Aktuelle Wetterwarnungen (DWD)</div><div id="warnItemsDwd"></div></div><div id="panelNina" class="warnlist-panel" role="tabpanel" aria-labelledby="tabNina" hidden><div class="title">Warnungen (BBK / NINA)</div><div id="warnItemsNina"></div></div></div>
   <footer class="footer">Radar: RainViewer • Satellit: EUMETSAT / DWD (CC BY 4.0) • Wind: Open-Meteo • Pegel: PEGELONLINE / WSV • OSM © Mitwirkende</footer>
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin></script>
-  <script src="https://unpkg.com/leaflet-velocity/dist/leaflet-velocity.min.js"></script>
-  <script type="module" src="/js/app.js"></script>
-</body>
-</html>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin></script><script src="https://unpkg.com/leaflet-velocity/dist/leaflet-velocity.min.js"></script><script type="module" src="/js/app.js"></script>
+</body></html>

--- a/js/app.js
+++ b/js/app.js
@@ -4,6 +4,7 @@ import * as Sat from './satellite.js';
 import { bind as bindWarnings } from './warnings.js';
 import { bindWindFlow } from './windflow.js';
 import { bindTemperature } from './temperature.js';
+import { bindWaterLevels } from './waterlevels.js';
 
 const map = L.map('map', { zoomSnap:0.5, worldCopyJump:true, maxZoom:10 }).setView([51.2,10.5], 6);
 const baseTiles = {
@@ -11,41 +12,28 @@ const baseTiles = {
   dark: L.tileLayer(OSM_DARK_URL, { maxZoom:19, attribution:OSM_DARK_ATTRIB }),
 };
 baseTiles.light.addTo(map);
-
-// Panes
-map.createPane('radarPane');  map.getPane('radarPane').style.zIndex = 450;
-map.createPane('cloudPane');  map.getPane('cloudPane').style.zIndex = 500;
+map.createPane('radarPane'); map.getPane('radarPane').style.zIndex = 450;
+map.createPane('cloudPane'); map.getPane('cloudPane').style.zIndex = 500;
 
 function applyDarkMode(enabled){
   document.body.classList.toggle('dark', enabled);
-  if(enabled){
-    if(map.hasLayer(baseTiles.light)) map.removeLayer(baseTiles.light);
-    if(!map.hasLayer(baseTiles.dark)) baseTiles.dark.addTo(map);
-  }else{
-    if(map.hasLayer(baseTiles.dark)) map.removeLayer(baseTiles.dark);
-    if(!map.hasLayer(baseTiles.light)) baseTiles.light.addTo(map);
-  }
+  if(enabled){ if(map.hasLayer(baseTiles.light)) map.removeLayer(baseTiles.light); if(!map.hasLayer(baseTiles.dark)) baseTiles.dark.addTo(map); }
+  else { if(map.hasLayer(baseTiles.dark)) map.removeLayer(baseTiles.dark); if(!map.hasLayer(baseTiles.light)) baseTiles.light.addTo(map); }
 }
 
-// UI
 const $ = id => document.getElementById(id);
 const ui = {
-  btnPrev: $('btnPrev'), btnNext:$('btnNext'), btnPlay:$('btnPlay'),
-  lblTime:$('lblTime'), btnLocate:$('btnLocate'), lblLocationWind:$('lblLocationWind'),
-  selColor:$('selColor'), chkSmooth:$('chkSmooth'), rngSpeed:$('rngSpeed'),
-  rngOpacity:$('rngOpacity'), lblOpacity:$('lblOpacity'),
-  chkClouds:$('chkClouds'), rngClouds:$('rngClouds'), lblClouds:$('lblClouds'),
-  chkWarn:$('chkWarn'), chkWarnList:$('chkWarnList'),
-  chkDark:$('chkDark'),
+  btnPrev:$('btnPrev'), btnNext:$('btnNext'), btnPlay:$('btnPlay'), lblTime:$('lblTime'), btnLocate:$('btnLocate'), lblLocationWind:$('lblLocationWind'),
+  selColor:$('selColor'), chkSmooth:$('chkSmooth'), rngSpeed:$('rngSpeed'), rngOpacity:$('rngOpacity'), lblOpacity:$('lblOpacity'),
+  chkClouds:$('chkClouds'), rngClouds:$('rngClouds'), lblClouds:$('lblClouds'), chkWarn:$('chkWarn'), chkWarnList:$('chkWarnList'), chkDark:$('chkDark'),
   chkWindFlow:$('chkWindFlow'), selWindRegion:$('selWindRegion'), lblWindFlowInfo:$('lblWindFlowInfo'),
-  controlPanel:$('controlPanel'),
-  btnPanelToggle:$('btnPanelToggle'),
+  chkWaterLevels:$('chkWaterLevels'), lblWaterLevelsInfo:$('lblWaterLevelsInfo'), controlPanel:$('controlPanel'), btnPanelToggle:$('btnPanelToggle'),
 };
 
-// Modules
 bindWarnings(L, map, ui);
 bindWindFlow(L, map, ui);
 bindTemperature(L, map);
+bindWaterLevels(L, map, ui);
 
 if(ui.btnPanelToggle && ui.controlPanel){
   ui.btnPanelToggle.onclick = ()=>{
@@ -55,197 +43,35 @@ if(ui.btnPanelToggle && ui.controlPanel){
     ui.btnPanelToggle.setAttribute('aria-label', collapsed ? 'Bedienpanel ausklappen' : 'Bedienpanel einklappen');
   };
 }
-
 function syncClouds(timeUnix){ Sat.syncTo(timeUnix); }
 
 async function boot(){
-  await Radar.loadRadar();
-  await Sat.loadSatellite();
-  Radar.paint(L, map, ui, syncClouds);
-
-  // Controls
+  await Radar.loadRadar(); await Sat.loadSatellite(); Radar.paint(L,map,ui,syncClouds);
   let playing=false, timer=null;
-  const stepMs = ()=> Math.max(Number(ui.rngSpeed.value), PLAY_FADE_MS+80);
+  const stepMs=()=>Math.max(Number(ui.rngSpeed.value),PLAY_FADE_MS+80);
+  ui.btnPrev.onclick=()=>{Radar.step(-1);Radar.paint(L,map,ui,syncClouds);};
+  ui.btnNext.onclick=()=>{Radar.step(+1);Radar.paint(L,map,ui,syncClouds);};
+  ui.btnPlay.onclick=()=>{ playing=!playing; ui.btnPlay.textContent=playing?'⏸':'▶︎'; if(playing) timer=setInterval(()=>{Radar.step(+1);Radar.paint(L,map,ui,syncClouds);},stepMs()); else clearInterval(timer); };
+  ui.rngSpeed.oninput=()=>{if(playing){clearInterval(timer);timer=setInterval(()=>{Radar.step(+1);Radar.paint(L,map,ui,syncClouds);},stepMs());}};
+  ui.rngOpacity.oninput=()=>{ui.lblOpacity.textContent=Math.round(Number(ui.rngOpacity.value)*100)+'%';};
+  ui.selColor.onchange=()=>Radar.paint(L,map,ui,syncClouds); ui.chkSmooth.onchange=()=>Radar.paint(L,map,ui,syncClouds);
+  ui.chkClouds.onchange=()=>Sat.toggle(L,map,ui.chkClouds.checked,Number(ui.rngClouds.value));
+  ui.rngClouds.oninput=()=>{ui.lblClouds.textContent=Math.round(Number(ui.rngClouds.value)*100)+'%';Sat.setOpacity(Number(ui.rngClouds.value));};
+  ui.chkDark.onchange=()=>applyDarkMode(ui.chkDark.checked); applyDarkMode(ui.chkDark.checked);
 
-  ui.btnPrev.onclick = ()=>{ Radar.step(-1); Radar.paint(L, map, ui, syncClouds); };
-  ui.btnNext.onclick = ()=>{ Radar.step(+1); Radar.paint(L, map, ui, syncClouds); };
-  ui.btnPlay.onclick = ()=>{
-    playing=!playing; ui.btnPlay.textContent = playing?'⏸':'▶︎';
-    if(playing){ timer=setInterval(()=>{ Radar.step(+1); Radar.paint(L,map,ui,syncClouds); }, stepMs()); }
-    else clearInterval(timer);
-  };
-  ui.rngSpeed.oninput = ()=>{ if(playing){ clearInterval(timer); timer=setInterval(()=>{ Radar.step(+1); Radar.paint(L,map,ui,syncClouds); }, stepMs()); }};
+  const locationTooltipOptions={permanent:true,direction:'top',offset:[0,-22],className:'wind-tooltip'};
+  let locateMarker=null,locateCircle=null;
+  function setWindBadge(text,visible=true){if(!ui.lblLocationWind)return;if(!visible){if(text)ui.lblLocationWind.textContent=text;ui.lblLocationWind.style.display='none';return;}if(!text){ui.lblLocationWind.textContent='';ui.lblLocationWind.style.display='none';return;}ui.lblLocationWind.textContent=text;ui.lblLocationWind.style.display='inline-block';}
+  const showWindLoading=()=>setWindBadge('Wind wird geladen…'); const showWindError=(msg='Winddaten nicht verfügbar')=>setWindBadge(msg);
+  const showWindInfo=info=>{if(!info)return setWindBadge('Winddaten nicht verfügbar');const d=Number.isFinite(info.direction)?`${Math.round(info.direction)}°`:'–';const s=Number.isFinite(info.speedKmh)?info.speedKmh.toFixed(1):'–';setWindBadge(`Wind: ${s} km/h (${d})`);};
+  function updateAccuracyCircle(lat,lon,accuracy){const r=Math.max(Number(accuracy)||0,30);const style={color:'#1976d2',weight:2,fillColor:'#64b5f6',fillOpacity:.18};if(locateCircle){locateCircle.setLatLng([lat,lon]);locateCircle.setRadius(r);locateCircle.setStyle(style);}else locateCircle=L.circle([lat,lon],{...style,radius:r}).addTo(map);}
+  function updateLocationMarker(lat,lon,direction){const rot=Number.isFinite(direction)?direction:0;const pointerStyle=Number.isFinite(direction)?`--rot:${rot}deg;`:'--rot:0deg;opacity:0;';const icon=L.divIcon({className:'loc-icon',html:`<div class="loc-marker"><div class="loc-pointer" style="${pointerStyle}"></div><div class="loc-marker__inner"></div></div>`,iconSize:[48,60],iconAnchor:[24,52],tooltipAnchor:[0,-32]});if(locateMarker){locateMarker.setLatLng([lat,lon]);locateMarker.setIcon(icon);}else locateMarker=L.marker([lat,lon],{icon}).addTo(map);return locateMarker;}
+  async function fetchWindInfo(lat,lon){const params=new URLSearchParams({latitude:lat.toFixed(3),longitude:lon.toFixed(3),current_weather:'true',windspeed_unit:'ms',timezone:'auto'});const res=await fetch(`https://api.open-meteo.com/v1/forecast?${params}`,{cache:'no-store'});if(!res.ok)throw new Error(`HTTP ${res.status}`);const cw=(await res.json())?.current_weather;if(!cw)throw new Error('Keine aktuellen Winddaten');const speedMsRaw=Number(cw.windspeed),directionRaw=Number(cw.winddirection??cw.wind_direction);const speedMs=Number.isFinite(speedMsRaw)?speedMsRaw:null;return{speedMs,speedKmh:speedMs==null?null:speedMs*3.6,direction:Number.isFinite(directionRaw)?directionRaw:null};}
+  function updateWindTooltip(marker,info){if(!marker)return;if(!info){if(marker.getTooltip())marker.setTooltipContent('Winddaten nicht verfügbar');else marker.bindTooltip('Winddaten nicht verfügbar',locationTooltipOptions);return;}const d=Number.isFinite(info.direction)?`${Math.round(info.direction)}°`:'–';const k=Number.isFinite(info.speedKmh)?info.speedKmh.toFixed(1):'–';const m=Number.isFinite(info.speedMs)?info.speedMs.toFixed(1):'–';const content=`Wind: ${k} km/h (${m} m/s)<br>Richtung: ${d}`;if(marker.getTooltip())marker.setTooltipContent(content);else marker.bindTooltip(content,locationTooltipOptions);}
+  ui.btnLocate.onclick=()=>{if(!navigator.geolocation){showWindError('Standortbestimmung nicht unterstützt');alert('Geolokalisierung wird von diesem Browser nicht unterstützt.');return;}ui.btnLocate.disabled=true;showWindLoading();navigator.geolocation.getCurrentPosition(async pos=>{const{latitude,longitude,accuracy}=pos.coords;const zoom=accuracy<=50?14:accuracy<=150?12:accuracy<=1000?10:9;map.setView([latitude,longitude],Math.min(zoom,map.getMaxZoom()));updateAccuracyCircle(latitude,longitude,accuracy);const marker=updateLocationMarker(latitude,longitude,null);try{const wind=await fetchWindInfo(latitude,longitude);updateLocationMarker(latitude,longitude,wind.direction??null);updateWindTooltip(marker,wind);showWindInfo(wind);}catch(err){console.warn('Winddaten konnten nicht geladen werden:',err);updateWindTooltip(marker,null);showWindError();}finally{ui.btnLocate.disabled=false;}},err=>{console.warn('Geolokalisierung fehlgeschlagen:',err);ui.btnLocate.disabled=false;showWindError('Standort nicht verfügbar');},{enableHighAccuracy:true,maximumAge:120000,timeout:15000});};
 
-  ui.rngOpacity.oninput = ()=>{
-    ui.lblOpacity.textContent = Math.round(Number(ui.rngOpacity.value)*100)+'%';
-  };
-  ui.selColor.onchange = ()=> Radar.paint(L,map,ui,syncClouds);
-  ui.chkSmooth.onchange = ()=> Radar.paint(L,map,ui,syncClouds);
-
-  ui.chkClouds.onchange = ()=> Sat.toggle(L, map, ui.chkClouds.checked, Number(ui.rngClouds.value));
-  ui.rngClouds.oninput = ()=>{ ui.lblClouds.textContent=Math.round(Number(ui.rngClouds.value)*100)+'%'; Sat.setOpacity(Number(ui.rngClouds.value)); };
-
-  ui.chkDark.onchange = ()=> applyDarkMode(ui.chkDark.checked);
-  applyDarkMode(ui.chkDark.checked);
-
-  const locationTooltipOptions = { permanent:true, direction:'top', offset:[0,-22], className:'wind-tooltip' };
-  let locateMarker=null, locateCircle=null;
-
-  function setWindBadge(text, visible=true){
-    if(!ui.lblLocationWind) return;
-    if(!visible){
-      if(text) ui.lblLocationWind.textContent = text;
-      ui.lblLocationWind.style.display = 'none';
-      return;
-    }
-    if(!text){
-      ui.lblLocationWind.textContent = '';
-      ui.lblLocationWind.style.display = 'none';
-      return;
-    }
-    ui.lblLocationWind.textContent = text;
-    ui.lblLocationWind.style.display = 'inline-block';
-  }
-  const showWindLoading = ()=> setWindBadge('Wind wird geladen…');
-  const showWindError = (msg='Winddaten nicht verfügbar')=> setWindBadge(msg);
-  const showWindInfo = info => {
-    if(!info) return setWindBadge('Winddaten nicht verfügbar');
-    const dirText = Number.isFinite(info.direction) ? `${Math.round(info.direction)}°` : '–';
-    const speedText = Number.isFinite(info.speedKmh) ? info.speedKmh.toFixed(1) : '–';
-    setWindBadge(`Wind: ${speedText} km/h (${dirText})`);
-  };
-
-  function updateAccuracyCircle(lat, lon, accuracy){
-    const safeRadius = Math.max(Number(accuracy) || 0, 30);
-    const style = { color:'#1976d2', weight:2, fillColor:'#64b5f6', fillOpacity:0.18 };
-    if(locateCircle){
-      locateCircle.setLatLng([lat, lon]);
-      locateCircle.setRadius(safeRadius);
-      locateCircle.setStyle(style);
-    }else{
-      locateCircle = L.circle([lat, lon], { ...style, radius: safeRadius }).addTo(map);
-    }
-  }
-
-  function updateLocationMarker(lat, lon, direction){
-    const rot = Number.isFinite(direction) ? direction : 0;
-    const pointerStyle = Number.isFinite(direction) ? `--rot:${rot}deg;` : '--rot:0deg;opacity:0;';
-    const icon = L.divIcon({
-      className:'loc-icon',
-      html:`<div class="loc-marker"><div class="loc-pointer" style="${pointerStyle}"></div><div class="loc-marker__inner"></div></div>`,
-      iconSize:[48,60], iconAnchor:[24,52], tooltipAnchor:[0,-32],
-    });
-    if(locateMarker){
-      locateMarker.setLatLng([lat, lon]);
-      locateMarker.setIcon(icon);
-    }else{
-      locateMarker = L.marker([lat, lon], {icon}).addTo(map);
-    }
-    return locateMarker;
-  }
-
-  async function fetchWindInfo(lat, lon){
-    const params = new URLSearchParams({
-      latitude: lat.toFixed(3),
-      longitude: lon.toFixed(3),
-      current_weather: 'true',
-      windspeed_unit: 'ms',
-      timezone: 'auto',
-    });
-    const res = await fetch(`https://api.open-meteo.com/v1/forecast?${params.toString()}`, { cache:'no-store' });
-    if(!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
-    const cw = data?.current_weather;
-    if(!cw) throw new Error('Keine aktuellen Winddaten');
-    const speedMsRaw = Number(cw.windspeed);
-    const directionRaw = Number(cw.winddirection ?? cw.wind_direction);
-    const speedMs = Number.isFinite(speedMsRaw) ? speedMsRaw : null;
-    return {
-      speedMs,
-      speedKmh: speedMs == null ? null : speedMs * 3.6,
-      direction: Number.isFinite(directionRaw) ? directionRaw : null,
-    };
-  }
-
-  function updateWindTooltip(marker, info){
-    if(!marker) return;
-    if(!info){
-      if(marker.getTooltip()) marker.setTooltipContent('Winddaten nicht verfügbar');
-      else marker.bindTooltip('Winddaten nicht verfügbar', locationTooltipOptions);
-      return;
-    }
-    const dirText = Number.isFinite(info.direction) ? `${Math.round(info.direction)}°` : '–';
-    const speedKmhText = Number.isFinite(info.speedKmh) ? info.speedKmh.toFixed(1) : '–';
-    const speedMsText = Number.isFinite(info.speedMs) ? info.speedMs.toFixed(1) : '–';
-    const content = `Wind: ${speedKmhText} km/h (${speedMsText} m/s)<br>Richtung: ${dirText}`;
-    if(marker.getTooltip()) marker.setTooltipContent(content);
-    else marker.bindTooltip(content, locationTooltipOptions);
-  }
-
-  ui.btnLocate.onclick = ()=>{
-    if(!navigator.geolocation){
-      showWindError('Standortbestimmung nicht unterstützt');
-      alert('Geolokalisierung wird von diesem Browser nicht unterstützt.');
-      return;
-    }
-    ui.btnLocate.disabled = true;
-    showWindLoading();
-    navigator.geolocation.getCurrentPosition(async pos=>{
-      const { latitude, longitude, accuracy } = pos.coords;
-      const zoom= accuracy<=50?14:accuracy<=150?12:accuracy<=1000?10:9;
-      map.setView([latitude,longitude], Math.min(zoom, map.getMaxZoom()));
-      updateAccuracyCircle(latitude, longitude, accuracy);
-      const marker = updateLocationMarker(latitude, longitude, null);
-      try{
-        const wind = await fetchWindInfo(latitude, longitude);
-        updateLocationMarker(latitude, longitude, wind.direction ?? null);
-        updateWindTooltip(marker, wind);
-        showWindInfo(wind);
-      }catch(err){
-        console.warn('Winddaten konnten nicht geladen werden:', err);
-        updateWindTooltip(marker, null);
-        showWindError();
-      }finally{
-        ui.btnLocate.disabled = false;
-      }
-    }, err=>{
-      console.warn('Geolokalisierung fehlgeschlagen:', err);
-      ui.btnLocate.disabled = false;
-      showWindError('Standort nicht verfügbar');
-    }, { enableHighAccuracy:true, maximumAge:120000, timeout:15000 });
-  };
-
-  // Marker für aktuelle Zeit
-  Radar.paint(L, map, ui, syncClouds);
-  const marker = document.getElementById('currentTimeMarker');
-  if (marker) {
-    const now = Date.now() / 1000;
-    const frames = Radar.getFrames();
-    const currentFrame = frames[Radar.getIndex()];
-    if (currentFrame && Math.abs(currentFrame.time - now) < 60) {
-      marker.style.display = 'block';
-    }
-  }
-
-  // regelmäßige Aktualisierung
-  setInterval(async ()=>{
-    await Promise.all([Radar.loadRadar(), Sat.loadSatellite()]);
-    const frames = Radar.getFrames();
-    const current = frames[Radar.getIndex()];
-    if(current) syncClouds(current.time);
-    Radar.paint(L,map,ui,syncClouds);
-    // Aktualisiere Marker
-    const now = Date.now() / 1000;
-    if (marker && frames[Radar.getIndex()] && Math.abs(frames[Radar.getIndex()].time - now) < 60) {
-      marker.style.display = 'block';
-    } else if (marker) {
-      marker.style.display = 'none';
-    }
-  }, 5*60*1000);
-
-  // Optional: Wind standardmäßig aktivieren
-  // ui.chkWindFlow.checked = true;
-  // ui.chkWindFlow.onchange();
+  Radar.paint(L,map,ui,syncClouds); const marker=document.getElementById('currentTimeMarker');
+  if(marker){const now=Date.now()/1000;const frames=Radar.getFrames();const currentFrame=frames[Radar.getIndex()];if(currentFrame&&Math.abs(currentFrame.time-now)<60)marker.style.display='block';}
+  setInterval(async()=>{await Promise.all([Radar.loadRadar(),Sat.loadSatellite()]);const frames=Radar.getFrames();const current=frames[Radar.getIndex()];if(current)syncClouds(current.time);Radar.paint(L,map,ui,syncClouds);const now=Date.now()/1000;if(marker&&frames[Radar.getIndex()]&&Math.abs(frames[Radar.getIndex()].time-now)<60)marker.style.display='block';else if(marker)marker.style.display='none';},5*60*1000);
 }
-
 boot();

--- a/js/waterlevels.js
+++ b/js/waterlevels.js
@@ -1,0 +1,109 @@
+const PEGELONLINE_BASE = 'https://www.pegelonline.wsv.de/webservices/rest-api/v2';
+const REFRESH_MS = 6 * 60 * 60 * 1000;
+
+let layer = null;
+let refreshTimer = null;
+let lastLoaded = 0;
+
+function statusMeta(state){
+  const s = String(state || '').toLowerCase();
+  if(s === 'low') return { label:'zu niedrig', color:'#1976d2' };
+  if(s === 'high') return { label:'zu hoch', color:'#d32f2f' };
+  if(s === 'normal') return { label:'normal', color:'#2e7d32' };
+  if(s === 'outdated') return { label:'veraltet', color:'#757575' };
+  if(s === 'unknown') return { label:'unbekannt', color:'#757575' };
+  return { label:s || 'unbekannt', color:'#757575' };
+}
+
+function escapeHtml(value){
+  return String(value ?? '').replace(/[&<>"']/g, ch => ({
+    '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;'
+  }[ch]));
+}
+
+async function fetchStations(){
+  const url = `${PEGELONLINE_BASE}/stations.json?includeTimeseries=true&includeCurrentMeasurement=true`;
+  const res = await fetch(url, { cache:'no-store' });
+  if(!res.ok) throw new Error(`PEGELONLINE HTTP ${res.status}`);
+  return res.json();
+}
+
+function getWaterLevel(station){
+  const series = Array.isArray(station?.timeseries) ? station.timeseries : [];
+  return series.find(item => item?.shortname === 'W' || item?.unit === 'cm') || null;
+}
+
+function stationLatLng(station){
+  const lat = Number(station?.latitude);
+  const lon = Number(station?.longitude);
+  return Number.isFinite(lat) && Number.isFinite(lon) ? [lat, lon] : null;
+}
+
+function markerFor(L, station){
+  const latlng = stationLatLng(station);
+  const series = getWaterLevel(station);
+  const measurement = series?.currentMeasurement;
+  const value = Number(measurement?.value);
+  if(!latlng || !Number.isFinite(value)) return null;
+
+  const status = statusMeta(measurement?.stateMnwMhw);
+  const icon = L.divIcon({
+    className:'pegel-marker',
+    html:`<div class="pegel-marker__inner" style="--pegel-color:${status.color}">${Math.round(value)}<span>cm</span></div>`,
+    iconSize:[48,34], iconAnchor:[24,17], popupAnchor:[0,-18]
+  });
+
+  const marker = L.marker(latlng, { icon });
+  const time = measurement?.timestamp ? new Date(measurement.timestamp).toLocaleString('de-DE') : '–';
+  marker.bindPopup(`
+    <div class="pegel-popup">
+      <strong>${escapeHtml(station?.longname || station?.shortname || 'Pegel')}</strong><br>
+      Gewässer: ${escapeHtml(station?.water?.longname || station?.water?.shortname || '–')}<br>
+      Pegel: <strong>${Math.round(value)} cm</strong><br>
+      Status: <strong style="color:${status.color}">${status.label}</strong><br>
+      <small>Stand: ${escapeHtml(time)}</small>
+    </div>
+  `);
+  marker.bindTooltip(`${escapeHtml(station?.shortname || station?.longname || 'Pegel')}: ${Math.round(value)} cm · ${status.label}`);
+  return marker;
+}
+
+async function load(L, map, ui, force=false){
+  if(!layer) layer = L.layerGroup();
+  if(!force && lastLoaded && Date.now() - lastLoaded < REFRESH_MS) return;
+
+  if(ui?.lblWaterLevelsInfo) ui.lblWaterLevelsInfo.textContent = 'Pegel werden geladen…';
+  try{
+    const stations = await fetchStations();
+    layer.clearLayers();
+    let count = 0;
+    for(const station of stations){
+      const marker = markerFor(L, station);
+      if(marker){ marker.addTo(layer); count++; }
+    }
+    lastLoaded = Date.now();
+    if(ui?.lblWaterLevelsInfo) ui.lblWaterLevelsInfo.textContent = `${count} Pegel · Stand ${new Date().toLocaleTimeString('de-DE',{hour:'2-digit',minute:'2-digit'})}`;
+  }catch(err){
+    console.warn('PEGELONLINE konnte nicht geladen werden:', err);
+    if(ui?.lblWaterLevelsInfo) ui.lblWaterLevelsInfo.textContent = 'Pegeldaten nicht verfügbar';
+  }
+}
+
+export function bindWaterLevels(L, map, ui){
+  if(!ui?.chkWaterLevels) return;
+  layer = L.layerGroup();
+
+  const sync = async force => {
+    if(ui.chkWaterLevels.checked){
+      await load(L, map, ui, force);
+      if(!map.hasLayer(layer)) layer.addTo(map);
+    }else if(map.hasLayer(layer)){
+      map.removeLayer(layer);
+    }
+  };
+
+  ui.chkWaterLevels.onchange = () => sync(false);
+  refreshTimer = setInterval(() => {
+    if(ui.chkWaterLevels.checked) sync(true);
+  }, REFRESH_MS);
+}


### PR DESCRIPTION
## Was ist neu?

- zuschaltbare Ebene **Pegelstände (WSV)** im Bedienpanel
- Daten über die PEGELONLINE REST API der Wasserstraßen- und Schifffahrtsverwaltung
- Marker zeigen den aktuellen Wasserstand direkt in **cm**
- farbliche Einstufung anhand des von PEGELONLINE gelieferten Status `stateMnwMhw`:
  - blau: zu niedrig
  - grün: normal
  - rot: zu hoch
  - grau: unbekannt/veraltet
- Klick auf einen Pegel zeigt Station, Gewässer, Pegelstand, Status und Zeitstempel
- automatische Aktualisierung alle **6 Stunden**, solange die Ebene aktiviert ist
- Quellenangabe im Footer ergänzt

## Hinweis

Die Einstufung verwendet bewusst die amtliche PEGELONLINE-Klassifizierung statt selbst definierter Grenzwerte.

Bitte vor Merge einmal im Browser testen, insbesondere ob der direkte PEGELONLINE-Abruf in der produktiven Umgebung durch CORS zugelassen wird. Falls nicht, sollte analog zu RainViewer/DWD ein kleiner Nginx-Proxy vorgeschaltet werden.